### PR TITLE
Replace semaphore wait with thread dispatch

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -271,19 +271,26 @@
     if ([self.webView isKindOfClass:UIWebView.class]) {
         result = [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:script];
     } else {
-        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-        [((WKWebView *)self.webView) evaluateJavaScript:script completionHandler:^(id resultID, NSError *error) {
-            result = [resultID description];
-            dispatch_semaphore_signal(semaphore);
-        }];
-
-        // Ugly way to convert the async call into a sync call.
-        // Since WKWebView calls back on the main thread we can't block.
-        while (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW)) {
-            [NSRunLoop.currentRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:10]];
-        }
+        runOnMainQueueWithoutDeadlocking(^{
+            [((WKWebView *)self.webView) evaluateJavaScript:script completionHandler:^(id resultID, NSError *error) {
+                result = [resultID description];
+            }];
+        });
     }
     return result;
+}
+
+// http://stackoverflow.com/questions/5225130/grand-central-dispatch-gcd-vs-performselector-need-a-better-explanation/5226271#5226271
+void runOnMainQueueWithoutDeadlocking(void (^block)(void))
+{
+    if ([NSThread isMainThread])
+    {
+        block();
+    }
+    else
+    {
+        dispatch_sync(dispatch_get_main_queue(), block);
+    }
 }
 
 - (BOOL)sendEventWithJSON:(id)JSON


### PR DESCRIPTION
Fixes #24 Very poor performance using the newer WkWebView engine

The fix does not affect current UIView Cordova builds but attempts to fix those that use the newer WKWebView builds. In its current state the plugin is not usable when using WkWebView. This is an attempt to fix that issue. 

My tests have shown this to work perfectly.

I am using an iPad Air 10.2 installed.
Cordova 6.5
Ionic 2.3.0
Ios-cordova 4.3.1

Please test this before accepting request.

[Stack Overflow](http://stackoverflow.com/questions/5225130/grand-central-dispatch-gcd-vs-performselector-need-a-better-explanation/5226271#5226271)