### PR TITLE
Add package.json to support using npm installation with newer Cordova.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.pspdfkit.cordovaplugin",
+  "version": "1.2.0",
+  "description": "PSPDFKit Cordova Plugin for iOS",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PSPDFKit/Cordova-iOS.git"
+  },
+  "keywords": [
+    "pspdfkit"
+  ],
+  "author": "PSPDFKit GmbH"
+}


### PR DESCRIPTION
It appears that Cordova 7.0 with plugins added to `config.xml` using git specs wants a `package.json` file. Without this file, `cordova create` fails when this is in my `config.xml`:
```xml
  <plugin name="com.pspdfkit.cordovaplugin" spec="https://github.com/PSPDFKit/Cordova-iOS.git#fae793a" />
```

By adding a package.json, this seems to be resolved.

I'm using node@6.10.1 and npm@4.4.4, with cordova@7.0.1. I haven't done extensive testing to identify which update adds this requirement.
