### PR TITLE
The completion handler is now called on the main queue after the document is saved

### DIFF
--- a/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
+++ b/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
@@ -1095,9 +1095,9 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 - (void)saveAnnotations:(CDVInvokedUrlCommand *)command
 {
-    NSError *error = nil;
-    [_pdfController.document save:&error];
-    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
+    [_pdfController.document saveWithCompletionHandler:^(NSError *error, NSArray<PSPDFAnnotation *> *savedAnnotations) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
+    }];
 }
 
 #pragma mark Configuration

--- a/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
+++ b/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
@@ -1095,6 +1095,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 - (void)saveAnnotations:(CDVInvokedUrlCommand *)command
 {
+    // Completion handler is called on the main queue
     [_pdfController.document saveWithCompletionHandler:^(NSError *error, NSArray<PSPDFAnnotation *> *savedAnnotations) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
     }];

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1095,9 +1095,10 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 - (void)saveAnnotations:(CDVInvokedUrlCommand *)command
 {
-    NSError *error = nil;
-    [_pdfController.document save:&error];
-    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
+    // Completion handler is called on the main queue
+    [_pdfController.document saveWithCompletionHandler:^(NSError *error, NSArray<PSPDFAnnotation *> *savedAnnotations) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
+    }];
 }
 
 #pragma mark Configuration


### PR DESCRIPTION
Before we were calling `save:` and right after that the completion handler. We had no guarantees that the completion block was executed after the save operation was complete. 

