### PR TITLE
Fix wrong scroll direction enum mapping

### DIFF
--- a/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
+++ b/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
@@ -561,8 +561,8 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
         
         @"PSPDFScrollDirection":
             
-  @{@"single": @(PSPDFScrollDirectionHorizontal),
-    @"double": @(PSPDFScrollDirectionVertical)},
+  @{@"horizontal": @(PSPDFScrollDirectionHorizontal),
+    @"vertical": @(PSPDFScrollDirectionVertical)},
         
         @"PSPDFLinkAction":
     

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -561,8 +561,8 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
         
         @"PSPDFScrollDirection":
             
-  @{@"single": @(PSPDFScrollDirectionHorizontal),
-    @"double": @(PSPDFScrollDirectionVertical)},
+  @{@"horizontal": @(PSPDFScrollDirectionHorizontal),
+    @"vertical": @(PSPDFScrollDirectionVertical)},
         
         @"PSPDFLinkAction":
     


### PR DESCRIPTION
Fixes #43.

The scroll direction was mapped using the wrong strings.
This PR fixes this and now uses "horizontal" and "vertical" for the scroll direction enum mapping.