### PR TITLE
Add annotation toolbar control methods.

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1259,6 +1259,38 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                                 callbackId:command.callbackId];
 }
 
+#pragma mark Annotation Toolbar methods
+
+- (void)hideAnnotationToolbar:(CDVInvokedUrlCommand *)command
+{
+    [_pdfController.annotationToolbarController updateHostView:nil container:nil viewController:_pdfController];
+    [_pdfController.annotationToolbarController hideToolbarAnimated:YES];
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
+                                callbackId:command.callbackId];
+}
+
+- (void)showAnnotationToolbar:(CDVInvokedUrlCommand *)command
+{
+    // Must be in document view mode when showing annotation toolbar
+    [_pdfController setViewMode:PSPDFViewModeDocument animated:YES];
+
+    [_pdfController.annotationToolbarController updateHostView:nil container:nil viewController:_pdfController];
+    [_pdfController.annotationToolbarController showToolbarAnimated:YES];
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
+                                callbackId:command.callbackId];
+}
+
+- (void)toggleAnnotationToolbar:(CDVInvokedUrlCommand *)command
+{
+    // Must be in document view mode when showing annotation toolbar
+    [_pdfController setViewMode:PSPDFViewModeDocument animated:YES];
+
+    [_pdfController.annotationToolbarController updateHostView:nil container:nil viewController:_pdfController];
+    [_pdfController.annotationToolbarController toggleToolbarAnimated:YES];
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
+                                callbackId:command.callbackId];
+}
+
 #pragma mark Delegate methods
 
 - (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldScrollToPage:(NSUInteger)page

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -179,6 +179,13 @@ var PSPDFKitPlugin = new function() {
     {
         callback(rightBarButtonItems);
     }
+
+    //annotation toolbar
+    addMethods({
+        hideAnnotationToolbar: [],
+        showAnnotationToolbar: [],
+        toggleAnnotationToolbar: [],
+    });
     
 };
 module.exports = PSPDFKitPlugin;

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ You can optionally set these toolbar buttons using the setOption(s) functions, o
 
 These methods retrieve the current left and right toolbar items arrays.
 
+    toggleAnnotationToolbar();
+    showAnnotationToolbar();
+    hideAnnotationToolbar();
+
+These methods control the display of the annotation toolbar.
+
 
 Custom toolbar button format
 ----------------------------


### PR DESCRIPTION
As there isn't a configuration option to automatically open the annotation toolbar, we use these methods to control when the viewer's launch context knows the user wants to dive right into editing.