### PR TITLE
Add PSPDFFlexibleToolbarContainerDelegate methods.

### DIFF
--- a/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
+++ b/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
@@ -14,7 +14,7 @@
 #import <WebKit/WebKit.h>
 #import <PSPDFKit/PSPDFKit.h>
 
-@interface PSPDFKitPlugin () <PSPDFViewControllerDelegate>
+@interface PSPDFKitPlugin () <PSPDFViewControllerDelegate, PSPDFFlexibleToolbarContainerDelegate>
 
 @property (nonatomic, strong) UINavigationController *navigationController;
 @property (nonatomic, strong) PSPDFViewController *pdfController;
@@ -1035,6 +1035,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     if (!_pdfController) {
         _pdfController = [[PSPDFViewController alloc] init];
         _pdfController.delegate = self;
+        [_pdfController annotationToolbarController].delegate = self;
         _navigationController = [[UINavigationController alloc] initWithRootViewController:_pdfController];
     }
 

--- a/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
+++ b/CordovaDemo/platforms/ios/CordovaDemo/Plugins/com.pspdfkit.cordovaplugin/PSPDFKitPlugin.m
@@ -1492,4 +1492,14 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     [self sendEventWithJSON:@{@"type": @"didHideHUD", @"animated": @(animated)}];
 }
 
+#pragma mark Annotation toolbar delegate methods
+
+- (void)flexibleToolbarContainerDidShow:(nonnull PSPDFFlexibleToolbarContainer *)container {
+    [self sendEventWithJSON:@"{type:'flexibleToolbarContainerDidShow'}"];
+}
+
+- (void)flexibleToolbarContainerDidHide:(nonnull PSPDFFlexibleToolbarContainer *)container {
+    [self sendEventWithJSON:@"{type:'flexibleToolbarContainerDidHide'}"];
+}
+
 @end

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -14,7 +14,7 @@
 #import <WebKit/WebKit.h>
 #import <PSPDFKit/PSPDFKit.h>
 
-@interface PSPDFKitPlugin () <PSPDFViewControllerDelegate>
+@interface PSPDFKitPlugin () <PSPDFViewControllerDelegate, PSPDFFlexibleToolbarContainerDelegate>
 
 @property (nonatomic, strong) UINavigationController *navigationController;
 @property (nonatomic, strong) PSPDFViewController *pdfController;
@@ -1035,6 +1035,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     if (!_pdfController) {
         _pdfController = [[PSPDFViewController alloc] init];
         _pdfController.delegate = self;
+        [_pdfController annotationToolbarController].delegate = self;
         _navigationController = [[UINavigationController alloc] initWithRootViewController:_pdfController];
     }
 
@@ -1490,6 +1491,16 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 - (void)pdfViewController:(PSPDFViewController *)pdfController didHideHUD:(BOOL)animated
 {
     [self sendEventWithJSON:@{@"type": @"didHideHUD", @"animated": @(animated)}];
+}
+
+#pragma mark Annotation toolbar delegate methods
+
+- (void)flexibleToolbarContainerDidShow:(nonnull PSPDFFlexibleToolbarContainer *)container {
+    [self sendEventWithJSON:@"{type:'flexibleToolbarContainerDidShow'}"];
+}
+
+- (void)flexibleToolbarContainerDidHide:(nonnull PSPDFFlexibleToolbarContainer *)container {
+    [self sendEventWithJSON:@"{type:'flexibleToolbarContainerDidHide'}"];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ The following events are supported by the PSPDFKitPlugin class
     didShowHUD
     shouldHideHUD
     didHideHUD
+    flexibleToolbarContainerDidShow
+    flexibleToolbarContainerDidHide
 
 
 License


### PR DESCRIPTION
This isn't a full accounting of `PSPDFFlexibleToolbarContainerDelegate` but adds the most useful events to know that editing mode was entered/exited.