### PR TITLE
Adds the ability to set `pageLabelEnabled` and `documentLabelEnabled`

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -966,6 +966,30 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return @(_pdfController.configuration.pageGrabberEnabled);
 }
 
+- (void)setPageLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageLabelEnabled
+{
+    [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+        builder.pageLabelEnabled = pageLabelEnabled.boolValue;
+    }];
+}
+
+- (NSNumber *)pageLabelEnabledAsJSON
+{
+    return @(_pdfController.configuration.pageLabelEnabled);
+}
+
+- (void)setDocumentLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)documentLabelEnabled
+{
+    [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+        builder.documentLabelEnabled = documentLabelEnabled.boolValue;
+    }];
+}
+
+- (NSNumber *)documentLabelEnabledAsJSON
+{
+    return @(_pdfController.configuration.documentLabelEnabled);
+}
+
 #pragma mark PDFProcessing methods
 
 - (void)convertPDFFromHTMLString:(CDVInvokedUrlCommand *)command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.2.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.2.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>


### PR DESCRIPTION
Reported in Z#10200

---

## How to Test:

* Modify `index.js` like so:

```javascript
        PSPDFKitPlugin.present('pdf/PSPDFKit Image Example.jpg', {
            pageTransition : 'curl',
            backgroundColor: 'white',
            pageLabelEnabled: '0',
            documentLabelEnabled: '0',
        });
```

* Launch Cordova Demo.
* Observe that the page label and the document label are not visible.

<img width="486" alt="iphone_8_plus_-_11_4" src="https://user-images.githubusercontent.com/7443038/44221981-26317b00-a151-11e8-8dbf-f3ba7b8eeec7.png">
