### PR TITLE
Add implementation for positioning annotation toolbar.

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1413,7 +1413,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 } 
 
 - (CGRect)flexibleToolbarContainerContentRect:(PSPDFFlexibleToolbarContainer *)container forToolbarPosition:(PSPDFFlexibleToolbarPosition)position {
-    // This is a workaround for handling the positioning of the annotation toolbar so that it's not covered by the components of the safe area.
+    // This calls though to the default PDF controller implementation that excludes main UI elements from the available content rect.
     // It is recommended that one calculates the positioning of the toolbar with respect to their own views.
     PSPDFViewController *controller = self.pdfController;
     if ([controller respondsToSelector:@selector(flexibleToolbarContainerContentRect:forToolbarPosition:)]) {

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1410,6 +1410,16 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 
 - (void)flexibleToolbarContainerDidHide:(nonnull PSPDFFlexibleToolbarContainer *)container {
     [self sendEventWithJSON:@"{type:'flexibleToolbarContainerDidHide'}"];
+} 
+
+- (CGRect)flexibleToolbarContainerContentRect:(PSPDFFlexibleToolbarContainer *)container forToolbarPosition:(PSPDFFlexibleToolbarPosition)position {
+    // This is a workaround for handling the positioning of the annotation toolbar so that it's not covered by the components of the safe area.
+    // It is recommended that one calculates the positioning of the toolbar with respect to their own views.
+    PSPDFViewController *controller = self.pdfController;
+    if ([controller respondsToSelector:@selector(flexibleToolbarContainerContentRect:forToolbarPosition:)]) {
+        return [controller flexibleToolbarContainerContentRect:container forToolbarPosition:position];
+    }
+    return container.bounds;
 }
 
 @end


### PR DESCRIPTION
This adds a fallback workaround to correctly incorporate the safeAreaInsets of newer devices with notches for the positioning of the `PSPDFAnnotationToolbar`. 

Related internal ticket 18423 can checked for more details.