### PR TITLE
Adds the ability to disable auto save

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -21,6 +21,7 @@
 @property (nonatomic, strong) PSPDFViewController *pdfController;
 @property (nonatomic, strong) PSPDFDocument *pdfDocument;
 @property (nonatomic, strong) NSDictionary *defaultOptions;
+@property (nonatomic) BOOL disableAutomaticSaving;
 
 @end
 
@@ -713,6 +714,16 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     }];
 }
 
+- (void)setDisableAutomaticSavingForPSPDFViewControllerWithJSON:(NSNumber *)shouldDisable
+{
+    self.disableAutomaticSaving = shouldDisable.boolValue;
+}
+
+- (NSNumber *)disableAutomaticSavingAsJSON
+{
+    return @(self.disableAutomaticSaving);
+}
+
 - (NSArray *)editableAnnotationTypesAsJSON
 {
     return _pdfController.configuration.editableAnnotationTypes.allObjects;
@@ -1317,6 +1328,11 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 }
 
 #pragma mark Delegate methods
+
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSaveDocument:(nonnull PSPDFDocument *)document withOptions:(NSDictionary<PSPDFDocumentSaveOption,id> *__autoreleasing  _Nonnull * _Nonnull)options
+{
+    return !self.disableAutomaticSaving;
+}
 
 - (void)pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.2.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.2.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>


### PR DESCRIPTION
# Details

Autosave can be disabled by passing `disableAutomaticSaving: true` as a configuration option.

## Usage:

```javascript
       PSPDFKitPlugin.present('pdf/PSPDFKit 8 QuickStart Guide.pdf', {
            pageTransition : 'curl',
            backgroundColor: 'white',
            disableAutomaticSaving: true
        });
```
# Acceptance Criteria

- [x] Adds the ability to disable autosave