### PR TITLE
Programmatic annotations and Forms API

### DIFF
--- a/CordovaDemo/platforms/ios/www/pdf/Form_example.pdf
+++ b/CordovaDemo/platforms/ios/www/pdf/Form_example.pdf
@@ -1,0 +1,643 @@
+%PDF-1.7%‚„œ”
+20 0 obj<</AcroForm 95 0 R/Extensions<</ADBE<</BaseVersion/1.7/ExtensionLevel 3>>>>/MarkInfo<</Marked false>>/Metadata 3 0 R/Names 96 0 R/OpenAction 21 0 R/Pages 16 0 R/Type/Catalog/ViewerPreferences<</Direction/L2R>>>>endobj95 0 obj<</DA(/Helv 0 Tf 0 g )/DR<</Encoding<</PDFDocEncoding 10 0 R>>/Font<</HeBo 8 0 R/Helv 9 0 R/ZaDb 115 0 R>>>>/Fields[108 0 R 109 0 R 110 0 R 111 0 R 112 0 R 113 0 R 116 0 R 117 0 R 121 0 R 122 0 R 129 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 106 0 R 107 0 R 114 0 R 118 0 R 119 0 R 120 0 R 123 0 R 124 0 R 125 0 R 7 0 R 128 0 R]/SigFlags 1>>endobj3 0 obj<</Length 21616/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.4-c005 78.147326, 2012/08/23-13:03:03        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stMfs="http://ns.adobe.com/xap/1.0/sType/ManifestItem#"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmpMM:InstanceID>uuid:24e746ca-8e98-a941-bee6-936d98995948</xmpMM:InstanceID>
+         <xmpMM:DocumentID>adobe:docid:indd:5235ff14-294b-11de-919f-d8c16f47bc75</xmpMM:DocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>5235ff13-294b-11de-919f-d8c16f47bc75</stRef:instanceID>
+            <stRef:documentID>adobe:docid:indd:87ea89f9-0d9e-11db-8dd1-d4ba47cf2fcb</stRef:documentID>
+         </xmpMM:DerivedFrom>
+         <xmpMM:Manifest>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stMfs:linkForm>ReferenceStream</stMfs:linkForm>
+                  <xmpMM:placedXResolution>72.00</xmpMM:placedXResolution>
+                  <xmpMM:placedYResolution>72.00</xmpMM:placedYResolution>
+                  <xmpMM:placedResolutionUnit>Inches</xmpMM:placedResolutionUnit>
+                  <stMfs:reference rdf:parseType="Resource">
+                     <stRef:instanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</stRef:instanceID>
+                     <stRef:documentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</stRef:documentID>
+                  </stMfs:reference>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpMM:Manifest>
+         <xmp:CreateDate>2009-04-14T17:42:58-07:00</xmp:CreateDate>
+         <xmp:ModifyDate>2014-03-06T17:57:29+01:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2014-03-06T17:57:29+01:00</xmp:MetadataDate>
+         <xmp:CreatorTool>Adobe InDesign CS3 (5.0.4)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4AE0Fkb2JlAGQAAAAAAQUAAilI/9sAhAAKBwcHBwcKBwcKDgkJCQ4RDAsLDBEU&#xA;EBAQEBAUEQ8RERERDxERFxoaGhcRHyEhISEfKy0tLSsyMjIyMjIyMjIyAQsJCQ4MDh8XFx8rIh0i&#xA;KzIrKysrMjIyMjIyMjIyMjIyMjIyMjI+Pj4+PjJAQEBAQEBAQEBAQEBAQEBAQEBAQED/wAARCAEA&#xA;AMYDAREAAhEBAxEB/8QBogAAAAcBAQEBAQAAAAAAAAAABAUDAgYBAAcICQoLAQACAgMBAQEBAQAA&#xA;AAAAAAABAAIDBAUGBwgJCgsQAAIBAwMCBAIGBwMEAgYCcwECAxEEAAUhEjFBUQYTYSJxgRQykaEH&#xA;FbFCI8FS0eEzFmLwJHKC8SVDNFOSorJjc8I1RCeTo7M2F1RkdMPS4ggmgwkKGBmElEVGpLRW01Uo&#xA;GvLj88TU5PRldYWVpbXF1eX1ZnaGlqa2xtbm9jdHV2d3h5ent8fX5/c4SFhoeIiYqLjI2Oj4KTlJ&#xA;WWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+hEAAgIBAgMFBQQFBgQIAwNtAQACEQMEIRIxQQVRE2Ei&#xA;BnGBkTKhsfAUwdHhI0IVUmJy8TMkNEOCFpJTJaJjssIHc9I14kSDF1STCAkKGBkmNkUaJ2R0VTfy&#xA;o7PDKCnT4/OElKS0xNTk9GV1hZWltcXV5fVGVmZ2hpamtsbW5vZHV2d3h5ent8fX5/c4SFhoeIiY&#xA;qLjI2Oj4OUlZaXmJmam5ydnp+So6SlpqeoqaqrrK2ur6/9oADAMBAAIRAxEAPwCbeU/KflW58q6L&#xA;cXGi6fNNNp9rJJJJaws7u0MbMzM0ZJJJ3OKpt/gzyf8A9WHTf+kOD/qnirv8GeT/APqw6b/0hwf9&#xA;U8Vd/gzyf/1YdN/6Q4P+qeKu/wAGeT/+rDpv/SHB/wBU8Vd/gzyf/wBWHTf+kOD/AKp4q7/Bnk//&#xA;AKsOm/8ASHB/1TxV3+DPJ/8A1YdN/wCkOD/qnirv8GeT/wDqw6b/ANIcH/VPFXf4M8n/APVh03/p&#xA;Dg/6p4q7/Bnk/wD6sOm/9IcH/VPFXf4M8n/9WHTf+kOD/qnirv8ABnk//qw6b/0hwf8AVPFXf4M8&#xA;n/8AVh03/pDg/wCqeKu/wZ5P/wCrDpv/AEhwf9U8Vd/gzyf/ANWHTf8ApDg/6p4q7/Bnk/8A6sOm&#xA;/wDSHB/1TxV3+DPJ/wD1YdN/6Q4P+qeKu/wZ5P8A+rDpv/SHB/1TxV3+DPJ//Vh03/pDg/6p4q7/&#xA;AAZ5P/6sOm/9IcH/AFTxV3+DPJ//AFYdN/6Q4P8Aqnirv8GeT/8Aqw6b/wBIcH/VPFXf4M8n/wDV&#xA;h03/AKQ4P+qeKpTrPlPyrFqOgJFounok+oSRyqtrCA6Cwv5OLgR7jkimh7gYqm3kz/lD9B/7Ztn/&#xA;AMmI8VYl5g83anYazd2cLsI4X4qA1BSgP8pymWEyN8RHy/U5ePLERHpifx70u/xzrH87/wDB/wDN&#xA;uD8vL+fL7P1M/Gj/ADI/b+t3+OdY/nf/AIP/AJtx/Ly/ny+z9S+NH+ZH7f1u/wAc6x/O/wDwf/Nu&#xA;P5eX8+X2fqXxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8Awf8Azbj+Xl/P&#xA;l9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W4eedYP7b/wDB/wDNmP5eX8+X2fqY&#xA;y1EB/BH7f1t/441j+d/+D/5sx/Ly/ny+z9SPzUP5kft/W7/HGsfzv/wf/NmP5eX8+X2fqX81D+ZH&#xA;7f1u/wAcax/O/wDwf/NmP5eX8+X2fqX81D+ZH7f1u/xxrH87/wDB/wDNmP5eX8+X2fqX81D+ZH7f&#xA;1u/xxrH87/8AB/8ANmP5eX8+X2fqX81D+ZH7f1u/xxrH87/8H/zZj+Xl/Pl9n6l/NQ/mR+39bv8A&#xA;HGsfzv8A8H/zZj+Xl/Pl9n6l/NQ/mR+39bX+OdY/nf8A4P8A5sx/Ly/ny+z9TIZ4n+CP2/rd/jnW&#xA;P53/AOD/AObcfy8v58vs/Unxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8A&#xA;wf8Azbj+Xl/Pl9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W7/HOsfzv/wAH/wA2&#xA;4/l5fz5fZ+pfGj/Mj9v63f451j+d/wDg/wDm3H8vL+fL7P1L40f5kft/WyryPr15rUl4t2zMIVjK&#xA;8mr9ovXsPDJ48Zh/ET72jPMSqoge5NNd/wCOp5c/7aUn/dO1LLGh3kz/AJQ/Qf8Atm2f/JiPFXmv&#xA;m6n+JNQ/4y/8ari2gmtkn2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xX1O2xX1O2xX1O2xX1O&#xA;2xX1O2xX1O2xX1O2xW5O2xW5O2xW5NH2xSCersLJ2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182n/AJ2TUP8AjL/xquLZVxSevvijh8nV98V4fJ1ffFeH&#xA;ydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV&#xA;98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFIjfRqpxZcAdU4rwB1a4UiIDO/wAr/wC+1H/Vh/XJgYZG&#xA;Ua7/AMdTy5/20pP+6dqWLW7yZ/yh+g/9s2z/AOTEeKvNfNv/ACkmof8AGX/jVcWyvSk+KK97sVr3&#xA;uxWve7Fa97sVr3uriyEHVxTwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8D&#xA;q4rwOrivA1WuFIjTO/yv/vtR/wBWH9cmBhkZRrv/AB1PLn/bSk/7p2pYtbvJn/KH6D/2zbP/AJMR&#xA;4q8183U/xJqFf9+/8ari2gmtkn2xW5dztsVuXc7bFbl3O2xW5dztsVuXc7bFbl3O2xW5dztsVuXc&#xA;7bFbl3O2xW5dzW2FIJ6uxZOxV2KuxV2KuxV2KuxV2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182/8pJqH/GX/AI1XFs2oJPv4Yo273b+GK7d7t/DFdu92&#xA;/hiu3e7fwxXbvdv4Yrt3u38MV273b+GK7d7t/DFdu91adsUgA9XVxTwebq4rwebq4rwebq4rwebq&#xA;4rwebq4rwebq4rwebq4rwebVcLIRp2KXYqzv8r/77Uf9WH9cmBryMo13/jqeXP8AtpSf907UsWt3&#xA;kz/lD9B/7Ztn/wAmI8Vea+bqf4k1D/jL/wAari2i6SfbwxX1N8j4nBwhl4mTvdyPiceEL4mTva29&#xA;8LEmR6u2xX1O2xT6nbYr6nbYr6nbYr6nbYr6nAKe9MSSkRkeoboviPx/pgs9yeE94+11F8R+ONnu&#xA;RwnvDW2FHqdtivqdtivqdtivqawsnYq7FXYqzv8AK/8AvtR/1Yf1yYGvIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFXmvm6v+JNQp/v3/jVcWwVW6T74p9Dt8V9Dt8V9Dt8V9Dt8VBiGqHCn&#xA;jDqHFeMOocV4w6hxSJAuxS7FXYq7FXYq7FXYq7FXYq7FXYq7FWd/lf8A32o/6sP65MDXkZRrv/HU&#xA;8uf9tKT/ALp2pYtbvJn/ACh+g/8AbNs/+TEeKvNfNv8Aykmob/7t/wCNVxbBy5JP9OK/B304r8Hf&#xA;Tivwd9OK/B304r8HfTivwd9OK/B304r8HfTimz3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3Oo&#xA;MV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3NHCyiSWd/lf/AH2o/wCrD+uTAwyMo13/AI6n&#xA;lz/tpSf907UsWt3kz/lD9B/7Ztn/AMmI8Vea+bf+Ul1D/jL/AMari2gXFJ6++KOHydX3xXh8nV98&#xA;V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFRHyaqcLLgDqnFeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDqn&#xA;FeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDq4pEQGd/lf8A32o/6sP65MDDIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFUn1fyKup6lcX5cj125U9Xj2A6fV38PHKpHNewFe/8AY5OOWERFmV/D&#xA;9aD/AOVbL/vw/wDI4f8AZLkeLP3R+Z/Uz49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98v&#xA;kP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q&#xA;/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9&#xA;bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u&#xA;/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/&#xA;AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1oPVvJdno1m19eSP6SsFPCUE1Y0G31YYeLP3R+Z/Uo&#xA;lgPWXyH60i9Py3/Pc/8ABD/qhjefuj8z+plWDvl8h+t3p+W/57n/AIIf9UMbz90fmf1LWDvl8h+t&#xA;3p+W/wCe5/4If9UMbz90fmf1LWDvl8h+t3p+W/57n/gh/wBUMbz90fmf1LWDvl8h+t3p+W/57n/g&#xA;h/1QxvP3R+Z/UtYO+XyH63en5b/nuf8Agh/1QxvP3R+Z/UtYO+XyH63en5b/AJ7n/gh/1QxvP3R+&#xA;Z/UtYO+XyH63en5b/nuf+CH/AFQxvP3R+Z/UtYO+XyH63en5b/nuf+CH/VDG8/dH5n9S1g75fIfr&#xA;Zj+Xq6Yst9+j2lY8YufqEHu9KUjTJwOT+ID4NGo4NuG/inmu/wDHU8uf9tKT/unalk2h3kz/AJQ/&#xA;Qf8Atm2f/JiPFUZPeSRysNggNAB9ogAln5H4QARSh+/cDKJ5SC5GPCJRXWt48spik4kEEoy70KEK&#xA;6P7g/wARTbc4splKijLhEY2Ff6xFzdKmsZVW+E0q9OIBpQ9e2XNCx722QzBmI+rlVk+FjQvTiBtv&#xA;9odMVpd9Zh5lOW4Xn0PTb/moYrStirsVdirsVdirsVdirGfzA/5RuX/jLH/xLFlDm8owtzsVdirs&#xA;VdirsVdirsVdirO/yv8A77Uf9WH9cmBryMo13/jqeXP+2lJ/3TtSxa3eTP8AlD9B/wC2bZ/8mI8V&#xA;VdQiIdmliLxHZSqPLQEq7ApGrtXkvh4bg9cTPHfcbfP7nN089tjv8B9pVbCGQsszKyIqH7f2ndzz&#xA;ZqFVIAqaVA69BQZPDA3bXqJiiPxQRLWiM0r82UylGNKfCUpQrVT4d8yHGtDtaiQysUdTcmJ3FRRS&#xA;pAqKoeyCo3GKbbNvycSLCVaRFjLhhyVW615L+zwH34ravHNO1A0LKOIPIkbkkilNt6CvTFC+N5HN&#xA;HTiOKmte5rUbgHbFVTFXYq7FXYq7FWM/mB/yjcv/ABlj/wCJYsoc3lFMWzjDqYrxh1MV4w6mK8Yd&#xA;TFeMOpivGHUxXjDqYrxh1MV4wzv8sP77Uf8AVh/XJixyMo13/jqeXP8AtpSf907UsWt3kz/lD9B/&#xA;7Ztn/wAmI8VSvVZdXGoTiDR7m4iDfDKl3JGrCg3CKaDKJ6aEjZJ+Z/W5ENXOEaAH+lH6kJ62u/8A&#xA;Viu/+k6X/mrB+Th3y/00v1svz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX89k7o/6WP6ne&#xA;trv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw75f6aX61/PZO6&#xA;P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX&#xA;89k7o/6WP6netrv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw7&#xA;5f6aX61/PZO6P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qTAeYPNIFP8PPt/xcP+&#xA;acyHFb/xD5p/6l5v+Rw/5pxVDX2pa9qVubW98ttLESGKmam46dFyOTGJiizxZZY5WEt/R8//AFKR&#xA;/wCkg5R+Tx/0v9NL9bf+fy+XyH6k00Xy/Y3/AK36T0L9H+nw9OsrPz5cuXh0oPvx/J4/6X+ml+tf&#xA;z+Xy+Q/Umn+DvLv/ACxr/wAE3/NWP5PH/S/00v1r+fy+XyH6nf4O8u/8sa/8E3/NWP5PH/S/00v1&#xA;r+fy+XyH6nf4O8u/8sa/8E3/ADVj+Tx/0v8ATS/Wv5/L5fIfqd/g7y7/AMsa/wDBN/zVj+Tx/wBL&#xA;/TS/Wv5/L5fIfqd/g7y7/wAsa/8ABN/zVj+Tx/0v9NL9a/n8vl8h+p3+DvLv/LGv/BN/zVj+Tx/0&#xA;v9NL9a/n8vl8h+p3+DvLv/LGv/BN/wA1Y/k8f9L/AE0v1r+fy+XyH6kbp2i6bpJkawgEJlAD0JNe&#xA;NadSfHLcWGOPlfxJP3tWbUTy1f3BB67/AMdTy5/20pP+6dqWWNTvJn/KH6D/ANs2z/5MR4qmDalY&#xA;JN9Xa4QTVC+nX4uR6CmKq/qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/w&#xA;Df0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xVfirsVUp7iC2j9W4dYkBpyY0&#xA;FTiqjFqen3D+nBOkr9eKHkaD2GKoj1V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq&#xA;71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq2rhuldvEEfrGKpPrv/HU8uf9tKT/&#xA;ALp2pYq7yZ/yh+g/9s2z/wCTEeKrppvKqX5Nx9RF+rgkssfrCQU47kcuXhiqa+qvg3/AN/TFXeqv&#xA;g3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/A&#xA;N/TFXeqvg3/AN/TFV+KuxVQu7a1u4TDeRLPESCUdeYqOm1DiqGtdM0iyl9ezs44JaEc44SpoeoqF&#xA;xVG+qvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXe&#xA;qvg3/AN/TFXeqvg3/AN/TFW1cN0rt4gj9YxVJ9d/46nlz/tpSf8AdO1LFXeTP+UP0H/tm2f/ACYj&#xA;xVbd3XlCK8c3v1FbxGBdpET1Aw6EsVrXFVf/ABR5e/6uEH/BjFXf4o8vf9XCD/gxirv8UeXv+rhB&#xA;/wAGMVd/ijy9/wBXCD/gxirv8UeXv+rhB/wYxVs+ZvL4AP6Rt9/8sHFWv8UeXv8Aq4Qf8GMVbPmb&#xA;y+KV1G338HB/ViqItNV0+/DNZTrchCAxiq1CeleIxVGYq7FVC7vLWxhNxeSrBECAXc0FT0xVA/4o&#xA;8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFWx5m0Agkahbmnb1F&#xA;B/4YjFWl8zaETvfQL7mWP+DnFUVaanaX6s9k63CoaMY2RgD4Gj4qiObf77b71/5qxV3Nv99t96/8&#xA;1Yq2rFuqlfnT+BOKpPrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/AOTEeKq9w/l0TuLtrIT1+MSm&#xA;LnX/ACuW+VS1OKJoyAPvbo6XNMWISI9xU/V8qfz6f98OR/N4P58fmGX5LUfzJfIu9Xyp/Pp/3w4/&#xA;m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bwfz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfI&#xA;u9Xyp/Pp/wB8OP5vB/Pj8wv5LUfzJfIu9Xyp/Pp/3w4/m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bw&#xA;fz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfIqsGoeX7YEW1zZwhvtCOSJa08eJGP5vB/&#xA;Pj8wv5LUfzJfIpll7juxVQvDZCAm/MQgqKmfjwr2+3tkZzjAWTQZQxymaiLPkl/q+VP59P8Avhyr&#xA;83g/nx+YbvyWo/mS+Rd6vlT+fT/vhx/N4P58fmF/Jaj+ZL5F3q+VP59P++HH83g/nx+YX8lqP5kv&#xA;kXer5U/n0/74cfzeD+fH5hfyWo/mS+Rd6vlT+fT/AL4cfzeD+fH5hfyWo/mS+Rd6vlT+fT/vhx/N&#xA;4P58fmF/Jaj+ZL5FWh1Dy/bArb3VnCGNSI5IlBP+xIx/N4P58fmF/Jaj+ZL5FU/TOj/8t9t/yOT/&#xA;AJqx/N4P58fmF/Jaj+ZL5F36Z0f/AJb7b/kcn/NWP5vB/Pj8wv5LUfzJfIq1ve2d2WFpcRTlKcvS&#xA;dXpXpXiTlmPNDJ9JB9zXkwZMf1RI94SzXf8AjqeXP+2lJ/3TtSybW7yZ/wAofoP/AGzbP/kxHiqh&#xA;fw+bGvJTYpp5ti37szB/Up/lUwGMT0ZCch1Q/oed/wDfel/8C+Dgj3L4ku93oed/996X/wAC+PBH&#xA;uXxJd7vQ87/770v/AIF8eCPcviS73eh53/33pf8AwL48Ee5fEl3u9Dzv/vvS/wDgXx4I9y+JLvd6&#xA;Hnf/AH3pf/AvjwR7l8SXe70PO/8AvvS/+BfHgj3L4ku93oed/wDfel/8C+PBHuXxJd7vQ87/AO+9&#xA;L/4F8eCPcviS71T/AJ37/tW/8lMkxd/zv3/at/5KYq0y+fHFGGmsPAiQ4CAUgkclnoed/wDfel/8&#xA;C+Dgj3J8SXe70PO/++9L/wCBfHgj3L4ku93oed/996X/AMC+PBHuXxJd7vQ87/770v8A4F8eCPcv&#xA;iS73eh53/wB96X/wL48Ee5fEl3u9Dzv/AL70v/gXx4I9y+JLvRFlB5r+txfpCPTvqtf3vpK3On+T&#xA;y2x4I9y+JLvT30IP99p/wIx4I9y+JLvd6EH++0/4EY8Ee5fEl3rljjT7Cha9aADCIgckGRPNJ9d/&#xA;46nlz/tpSf8AdO1LCh3kz/lD9B/7Ztn/AMmI8VX3XmnRLK4ktbm5CSxHi606HFVH/Gfl3/lrH3HF&#xA;Xf4z8u/8tY+44q7/ABn5d/5ax9xxV3+M/Lv/AC1r9xxVtvOXlwGgvFb3AP8AEDFU0tryO7gS5tla&#xA;SKUckccaEeO7Yqq82/3233r/AM1Yq7m3++2+9f8AmrFXc2/3233r/wA1YqvxV2KoTUdStNJtTeXz&#xA;mOFSFLAFt22GygnFUFp3mnRtVuPqlhK00xUtx4Muw67uFGKprzb/AH233r/zVirubf77b71/5qxV&#xA;3Nv99t96/wDNWKu5t/vtvvX/AJqxV3Nv99t96/8ANWKu5t/vtvvX/mrFXc2/3233r/zVirubf77b&#xA;71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxVNzFETUopJ7kDFXe&#xA;jD/vtfuGKu9GH/fa/cMVd6MP++1+4Yq70Yf99r9wxV3ow/77X7hiq4AAUAoB2GKt4q7FXYq7FXYq&#xA;hNR1K00m1N5fOY4VIUsAW3bYbKCcVSj/AB35Z/5aW/5FSf8ANOKu/wAd+Wf+Wlv+RUn/ADTirv8A&#xA;Hfln/lpb/kVJ/wA04q7/AB35Z/5aW/5FSf8ANOKtjz15YIJ+tkEdvSlqf+ExVr/Hfln/AJaW/wCR&#xA;Un/NOKq9l5v0LULqOzs5mknlJCJ6brWgLHdgB0GKpxzb/fbfev8AzVirubf77b71/wCasVbVi3VS&#xA;vzp/AnFUn13/AI6nlz/tpSf907UsVd5M/wCUP0H/ALZtn/yYjxVGzavp0ErQyzcXQ0YcXND9C5VL&#xA;U44miXIho8042Bss/Tulf7//AOEf/mnI/m8Xey/IZ/5v3O/Tulf7/wD+Ef8A5px/N4u9fyGf+b9z&#xA;v07pX+//APhH/wCacfzeLvX8hn/m/c79O6V/v/8A4R/+acfzeLvX8hn/AJv3O/Tulf7/AP8AhH/5&#xA;px/N4u9fyGf+b9zv07pX+/8A/hH/AOacfzeLvX8hn/m/c79O6V/v/wD4R/8AmnH83i71/IZ/5v3O&#xA;/Tulf7//AOEf/mnH83i71/IZ/wCb9zv07pX+/wD/AIR/+acfzeLvX8hn/m/cmGXuK7FVK4uYbSIz&#xA;XDcEBArQnc/6oORnOMBZZ48UskqjzQn6d0r/AH//AMI//NOVfm8Xe3/kM/8AN+536d0r/f8A/wAI&#xA;/wDzTj+bxd6/kM/837nfp3Sv9/8A/CP/AM04/m8Xev5DP/N+536d0r/f/wDwj/8ANOP5vF3r+Qz/&#xA;AM37nfp3Sv8Af/8Awj/804/m8Xev5DP/ADfud+ndK/3/AP8ACP8A804/m8Xev5DP/N+536d0r/f/&#xA;APwj/wDNOP5vF3r+Qz/zfud+ndK/3/8A8I//ADTj+bxd6/kM/wDN+536d0r/AH//AMI//NOP5vF3&#xA;r+Qz/wA37le1v7S9LC2k5lKcvhYUr/rAZPHmhk5Fqy6fJi+oJdrv/HU8uf8AbSk/7p2pZY1O8mf8&#xA;ofoP/bNs/wDkxHiqhf2HnCW8lksNUhgtmasUTRKxUU6EmJv14qh/0Z58/wCrzB/yJT/qhirv0Z58&#xA;/wCrzB/yJT/qhirv0Z58/wCrzB/yJT/qhiqvBaedYVKyX9ncEmvKWIig8B6Sx4qq+l5y/wCWjT/+&#xA;Rcv/ADViqHnsfPEzho9TtLcAU4xxVBO+/wC8SQ/jiqn+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8A&#xA;kSn/AFQxV36M8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M&#xA;8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp&#xA;/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp/wBUMVTfRrfW&#xA;reKRdau0vJGYGNo0CBVp0+FE74qmWKuxV2KpLrv/AB1PLn/bSk/7p2pYq7yZ/wAofoP/AGzbP/kx&#xA;Hiqbky12VSPdiP8AjXFXVm/lX/gj/wA0Yq6s38q/8Ef+aMVdWb+Vf+CP/NGKurN/Kv8AwR/5oxV1&#xA;Zv5V/wCCP/NGKurN/Kv/AAR/5oxV1Zv5V/4I/wDNGKurN/Kv/BH/AJoxV1Zv5V/4I/8ANGKr8Vdi&#xA;qnOvKMjjz9q0xViF3pVw91O48tPMGkciUamU51Y/Fw5/DXrTFU+0XSLSxjW6jtGs7mZAJYmnefjv&#xA;XjyZ2X6Riqa4qh76S7htZJbKEXM6iqQlgnPfpybYYqkv6W83f9WBf+kuLFXfpbzd/wBWBf8ApLix&#xA;VN9Nmv7i2Euo2ws5iSPRDiSgHQ81NN8VReKuxV2KpLrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/&#xA;AOTEeKpVquna/NqM8lrpOn3ELNVJZq+owoN2/fL+rKJ6TDM2YglyIa3PCNCRAQn6K8zf9WPS/uP/&#xA;AFXyP5HT/wAwMv5R1P8APKrb6Zrikm68v6fKP2RG/pmviSzyfqx/I6f+YF/lHU/zyr/o+/8A+pZs&#xA;/wDpIX/mjH8jp/5gX+UdT/PLv0ff/wDUs2f/AEkL/wA0Y/kdP/MC/wAo6n+eXfo+/wD+pZs/+khf&#xA;+aMfyOn/AJgX+UdT/PKaWGiWM1uHv9Kt7WepBjUiQAdjyAGP5HT/AMwL/KOp/nlE/wCH9E/5YYf+&#xA;BGP5HT/zAv8AKOp/nl3+H9E/5YYf+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf5&#xA;5d/h/RP+WGH/AIEY/kdP/MC/yjqf55d/h/RP+WGH/gRj+R0/8wL/ACjqf55d/h/RP+WGH/gRj+R0&#xA;/wDMC/yjqf55d/h/RP8Alhh/4EY/kdP/ADAv8o6n+eXf4f0T/lhh/wCBGP5HT/zAv8o6n+eXf4f0&#xA;T/lhh/4EY/kdP/MC/wAo6n+eXf4f0T/lhh/4EY/kdP8AzAv8o6n+eXf4f0T/AJYYf+BGP5HT/wAw&#xA;L/KOp/nl3+H9E/5YYf8AgRj+R0/8wL/KOp/nl3+H9E/5YYf+BGP5HT/zAv8AKOp/nl3+H9E/5YYf&#xA;+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf55RFpp1jYljZwJAZKcuApWnSv35bi&#xA;wY8X0imrNqcuauKVpdrv/HU8uf8AbSk/7p2pZY1O8mf8ofoP/bNs/wDkxHiqzW4ZJLdhHDeSn1lN&#xA;LOQRPSku/Iharv4ntiqR/Urn/li1v/pLX/mrFXfUrn/li1v/AKS1/wCasVTjStCR1hvpZdRt5EcP&#xA;9XuLkt9htg4FQQaYqyHFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FUl13/jqeXP+&#xA;2lJ/3TtSxV3kz/lD9B/7Ztn/AMmI8VXa5ZCW1AS3uLotKrFLaVYXFBJ8RaqVHxdK4qk0OjLIzCWw&#xA;1GABSwZ7wsCR0Uem7mp99sVU/wBFP/1adT/6TV/6rYqitPiudNnNxBpGoM5UpSW6jkWhoejSnwxV&#xA;NE1fVGdVbRrhFYgFjJDQA99pMVTfFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYqkuu/&#xA;8dTy5/20pP8AunalirvJn/KH6D/2zbP/AJMR4qq+YLQ3lkkQs3v6ShvSimEBFFccuZZa9aUxVJ7D&#xA;SWgkkY6NPa8o3Xk92Jw1R9gKDLQn+ag+eKoX9Bt/1L1z/wBxFf8Aqtirv0G3/UvXP/cRX/qtiqYa&#xA;R5ftjcCe50yewe3ZJIi92ZgzA1+ykjdKd8VZPirsVdirsVdirsVdiqHvb620+A3N3IIogQCzEAVP&#xA;TriqXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVd/i3QP+WyP/AIJf+asVd/i3QP8Alsj/AOCX&#xA;/mrFXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVbXzXoLMFW7jJJoByXqf9liqa82/3233r/zV&#xA;irubf77b71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxV3mC2GoW&#xA;ggm09b9Y5lZY3na3HSRefMAV+Xv7Yqg9F0HSoBJPJp6abOwaLit0bjlGwFd2NBv7VxVU/wAG+Uf+&#xA;WVf+R8v/AFVxVcPJPlVhVbIEeImmP/M3FW/8D+V/+WH/AJKzf9VcVTexsbXTbVLKyT0oIq8EqWpy&#xA;Jc7uSepxVEYq7FXYq7FXYq7FVrxxyrwkUOvgwBH44qpfUrP/AJZ4v+AX+mKu+pWf/LPF/wAAv9MV&#xA;d9Ss/wDlni/4Bf6Yq76lZ/8ALPF/wC/0xV31Kz/5Z4v+AX+mKu+pWf8Ayzxf8Av9MVd9TsxuII/+&#xA;AX+mKq+KuxV2KpLrv/HU8uf9tKT/ALp2pYq7yZ/yh+g/9s2z/wCTEeKo280fT9QQxXsInjLiTi2w&#xA;DDnQ/DQ/tnFUF/g/y1/ywR/e/wDzVirv8H+Wv+WCP73/AOasVTOzsrXT7dbWzjEMKVKoK0FTU9a9&#xA;ziqvirsVSjzLa3l5pvo2FfW9RSCpINBWu4zG1uPJkxEQ5uZ2dlx4s1z5MNPlzzcSSJ5AOw5HKI6e&#xA;QAuJ/wBOXKnqYGRrIK/qBr/Dfm//AH/J/wAEcP5c/wA0/wCnLH8xH/VB/wAqwq23l7zTHKrTSSOo&#xA;YEjk3QHfKsulzEjhBG+/qJbsOrwRB45CXd6AHoaAhFB60GbR0q7FUt163ubnTZIbSvrN9niaH8Mp&#xA;1MJTxER5uRo8kIZomXJhL+XPNjGqTSKPDkxzBwaXLGFTBJ/rl2WfV4ZyuEhEd3ACt/w35v8A9/yf&#xA;8Ect/Ln+af8ATlp/MR/1Qf8AKsL4/LvmtQeckj+HxsMx9To9ROuC4/5xcnTa3TQB4yJf5oD0G1Vk&#xA;tYUcUZY1DA+IArm2HJ0kyDIq2Fi7FXYq7FXYq7FUl13/AI6nlz/tpSf907UsVSnyn5s8q23lXRbe&#xA;41rT4ZodPtY5I5LqFXR1hjVlZWkBBBG4xVNv8Z+T/wDq/ab/ANJkH/VTFXf4z8n/APV+03/pMg/6&#xA;qYq7/Gfk/wD6v2m/9JkH/VTFXf4z8n/9X7Tf+kyD/qpirv8AGfk//q/ab/0mQf8AVTFXf4z8n/8A&#xA;V+03/pMg/wCqmKu/xn5P/wCr9pv/AEmQf9VMVd/jPyf/ANX7Tf8ApMg/6qYq7/Gfk/8A6v2m/wDS&#xA;ZB/1UxV3+M/J/wD1ftN/6TIP+qmKu/xn5P8A+r9pv/SZB/1UxV3+M/J//V+03/pMg/6qYq7/ABn5&#xA;P/6v2m/9JkH/AFUxV3+M/J//AFftN/6TIP8Aqpirv8Z+T/8Aq/ab/wBJkH/VTFXf4z8n/wDV+03/&#xA;AKTIP+qmKu/xn5P/AOr9pv8A0mQf9VMVd/jPyf8A9X7Tf+kyD/qpirv8Z+T/APq/ab/0mQf9VMVd&#xA;/jPyf/1ftN/6TIP+qmKu/wAZ+T/+r9pv/SZB/wBVMVd/jPyf/wBX7Tf+kyD/AKqYq7/Gfk//AKv2&#xA;m/8ASZB/1UxVKdZ82eVZdR0B4ta090g1CSSVluoSEQ2F/HyciTYcnUVPcjFX/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Example of an Interactive PDF Form</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">PDF forms</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:creator>
+            <rdf:Bag/>
+         </dc:creator>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>forms</rdf:li>
+               <rdf:li>flat</rdf:li>
+               <rdf:li>fillable</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+         <pdf:Producer>Adobe PDF Library 8.0</pdf:Producer>
+         <pdf:Trapped>False</pdf:Trapped>
+         <pdf:Keywords>forms, flat, fillable</pdf:Keywords>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj96 0 obj<</AP 17 0 R>>endobj21 0 obj<</D[22 0 R/Fit]/S/GoTo>>endobj16 0 obj<</Count 1/Kids[22 0 R]/Type/Pages>>endobj22 0 obj<</Annots 184 0 R/ArtBox[0.0 0.0 612.0 792.0]/BleedBox[0.0 0.0 612.0 792.0]/Contents 195 0 R/CropBox[0.0 0.0 612.0 792.0]/MediaBox[0.0 0.0 612.0 792.0]/Parent 16 0 R/Resources<</ColorSpace<</CS0 137 0 R>>/ExtGState<</GS0 138 0 R>>/Font<</T1_0 149 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 186 0 R>>/Shading<</Sh0 153 0 R>>>>/Rotate 0/TrimBox[0.0 0.0 612.0 792.0]/Type/Page>>endobj184 0 obj[100 0 R 118 0 R 101 0 R 119 0 R 102 0 R 103 0 R 104 0 R 120 0 R 121 0 R 122 0 R 105 0 R 106 0 R 123 0 R 124 0 R 125 0 R 107 0 R 128 0 R 126 0 R 127 0 R 108 0 R 109 0 R 110 0 R 113 0 R 114 0 R 129 0 R 116 0 R 117 0 R 111 0 R 112 0 R]endobj195 0 obj<</Filter/FlateDecode/Length 8996>>stream
+HâÏWÀ™«˝ï&É€™⁄ı„Åe;ì4àß‚Dëëà"ÚˇYkÌ]›Gå ì¬Ös{’c◊~?>˘H¯À«K9Îú´èuX]gÌπßπé«á£§£ñâU;G;ÍŸéæ;˛||<>Ø˛&Ô?É@=˚‘Æ˛•√@bçeu‚Ú8WÍVÍ πÔ~9^Ω˘5ü=~¯Â¯˛>}-’£5˚jÊ9€,e‡V*øÕ¡´◊†Ú ï≥,˛T˛î„¯¸¯xΩU\ñux†™r›*ÎÈÃµêÁøÚ≠7ˇx˚Ò¯Êõoø˝Ó˚◊«Ò√O¯˘$ =€ïm·˛”¡ﬂZ{ı«∑ﬂø{˜Ò˜_{„øY˚ˇkˇ√¸¯∑˜ˇÇ]´Ø~˛˚€«ªø¸¸˝è«´ü^ßCã_xµŒ≥èq‰÷ŒÖ*ÛÃs{i¬RS‡~ÛéöM∏uÏ¨¥J?Í∞sÊnkUÊ˛á„%üi|‚cµuº§séy!ˇ˜∏0($#™÷…t#∏BæÅ∆Í<ú⁄ÒROKù®u#ÍV/‘ŒÑÃÙx¬KGGËÁ¨UúA¶óÍ’Y®êÓeûu8gΩ!ﬁS&_≠L„…rfPÀÈ$ôrŒôÖñÒ1)A>≠n¢k°Á≈«+	Rº^nÙ •ﬂ€∞D+õ`Îª§C
+¨˛t{≠MÁKøemÙ–ù|r◊Œx∆$l@˝{‹^#MÌª‹Æ'⁄é|zç{ÅúÃ!ògó˚π’ÜÛ7—~"‘è—˝¯»óN=®≤4÷Ω]°pgnyÖ	¨BSö™ìã˚P’.QrøÓ
+Ø+$ôI§ﬁÈ·Ωà·>€Aq•/
+ôœÊ‹’Q f.dç˙∞ù. t!"CN¢;=)ììõÙqTm-∫)òÑûÏÿËÅ√p™ä≠$C°XN∑HFL|ê"Z◊
+Ô≈ŸÊ·XÎ«Ω0N[Y◊3m—·iÕï\≥‰tu—d¥pÉ¬ÇÙπ•‘g·∑`∫‚0U¥:ØÖRWìÈ¯¯TrP®Äµëä$&zaÇŒ«viÑÎπ[ê—ç√E˛X®¨‹√=©–$:≥Ñ£ÒKNFØ“2B¥”®Ω)^|Wgˆh¯‡#CbvÂ∆$sõY œ‡ ˆ@#3õ˘7Õ›ï∞@Üæ/9• Ëø%ñ⁄ˆ^FÆÇrß¥]–6AµNπñƒ^RÆÎà` Ù).Ø+[›bﬁç‚™$-0’∂¢Ïâ‰º<K,4A`ºx‡1 aäd€#a-Ê]ûm∞¥¬é^4ÚP¶]N∏üy…Ô—º	*ÉŸ?‡ÌM◊¬`™$É/,AU–≤<9’æèõã≠ºünûa◊ÖÓ8pº√§!ã‰ß(˙2Œd∑í¸ ä)aù˚µ¿⁄µñ‡Ç#;›ﬂC‹ÚÊ∏)®å)–ëlµÍ∫∑¡F!fwì§*(5B©ÜÊ…tDä’πúT<éu=Ú·˘°…DÒ‡©ﬂƒ8 ‚RçQ-S‘¢Iå£©‡Éêo>¡€t±@”vAc~Å·≥â˙íöëƒù˙î X(*D0ö)éfœpS˜Ö®Ô∏\:Cº®É—∫9'´l¸b–‰X˚f†õΩPË˙Ädê|‰&hUﬁΩzç„Ω´]PYµ‰FÜíyl√ˆD]∞boò*XÈä`t&7v±yÈºD<6	öIV,À„g©}BÆ(ﬁV¡˛⁄{zÇ6)∫+¬en˜´1Y¬ﬁ÷T6r®¥ﬂïY¿3Mæ0<∫UG’ÀúôõnÕàØÚ`Zùû3[Â~áìCuc-ﬂ¨}Ãu°«Näπ∏ë¯e§>∏càV\¬™˙áU6TÉRCd‹[Ö∆kCô¬#gXÄ˘çªF˛*kzÅ…
+A4EﬁØN*÷4ÜJ-:kŸ-√ö2{ç[¿‚•¨—µ–ƒ›`é€◊ôé«u¶‹j˜Î¥tæX„r™58∑À„KHÊçqÂ3ÔΩ©î§nE’“UF¥“ÿ⁄t8∑Æ˜>˚¸z_f€eudÅÏº‡m(ﬁ=Gp≈G˛`íg∂Èë X€·¥Qf†pî∆÷Hf®ˆ(f‘˛Â¥∂>)¨´;ê<<!{Ô]7’æIC6'\’¶eÛGªÏ?ùwçÕ®Xî¡¬°\8˜µ-xx!µR∑ªRcÛKﬂ}Ëq÷ÂÇûáû\2k=ãÙÜªä∆T~ê!PÂM^\.Ì`´íóLu7&‚±EÎnˆlÁnØ$ßúh9ˆ.{mƒÂæ™öìü(≥÷‰∂ﬂï-Cëû”ºò•K4D≠"˜ŸæJ(¬ùèy ±¶±S«•πTΩ%ÀÔÜ∑#∆¬˙wUﬂYY@€–:Êˆ€ZBñlıàõu±Õ∞j˛Ä§ä8OQËw$«4C≠»ÁÀ‹CóhèW*Y…e›ôÄpx1X"µ–∂Ω¸vkﬁ‘7mù>`¡õÖ8Ô]ônïêmµ*Òã⁄õΩ˚ñjîÍ4Bñ–úIçıjéû⁄ÄçÕg(ø 	l|· j«ÛX˚‚á'lﬁ’Zﬁ¯˙p“}ô”ÔpÚ“º©DËyï9ÅsKÃ›¸hœ⁄\MdGÒ^ÃˇÕÓ¿íì”Äz-Û,¢∑iN s◊E}Î`E;pmıÁK√N´¯Iç≤Ò‡D÷/fP&ü9e2ÈóSÛòD*≠=) —„Û®‘√X2W]yB—Éf,ïÎ&}s\toûÎ„UxMaÃmıb˝E∞+Y™∑!'ÚCØó8°T◊ÇåPî∑ˆÄrøºﬁ—„R˚µõòâ„&€®'≤aÕx4,MÜÍÂ‡∂ÜÀ‘≤‰ÀÅ™µ·^‘BúïÛQGÛrÃÍ≥—nÎízdì˛
+k1
+ê^ôÍÈØ[PGth Ò]Íz]7ß⁄;QUÚMÍ.Q™äÍpÙSJ!îL	≈ª;ï]ËÀKõÍ…KÚŸ¶∂È£ Óıu&4Lzhj∂ﬁ˛µ–Çö.”õÁM™#éÎq&–yqFÛÁªª+Qn	ùÃK^xòıKl*∑èf·‚iHZú"a:7’0@lÜq‚"«∂g≤ê }^è6ıŒ-_üx≠>1P9T©óêP§'O¯p€Y]Cr•{™o>°–n‡P~‹t√Uöm9zVu;aÚ5J+.ñy;V≤õnÿÂIOæÀ∆%#∏`36†ôÿ≠LêDë7v1=S8« µCúHëÆ¶zﬁöŸáü˘ª¬Éo‰g(∫I‹NüÉd.ˇñaG∫∂Ë.ìõEï’»å=d6«ÏxrˆvucÕ'ûÇ‡Ë°ˆ0ózÌÕ∑ÃHÂB+q÷q“lÍ7õèÜA◊Q WﬁªP„Ê]íPiÓﬁc¥É√õRpC† ≥Õ(˙Ò-kı±!Û⁄Ã“©ÿ&À%ÜßLVö±∫f4KH^–6Î≠—b ¨µ¨∏5≥≈∂Óì
+>'ò·ƒk]ÌbS∞ôù¶Ï[”⁄`ªh@dG5öN`‰…«m*`ª˙?4(YÅ6Ë=ö1K5ˇ§]õŒ8ÄP≈˚$h∞ πòc–+Â∑ÔL„ÛY —E”ûû(†K-‘„ﬂÃWYédπªJ^¿ÌÀ1¸Â$l¯#k €˜$CzzY›œ`¶‹h†Î1µK$/À∏6kSD-I8Xguh∑9!§3RHè<y>˛Ò¯Î„_3cˆèj˙<·øRAπﬂı„ë√√í¡◊lPUâê‹√øˇ˛¯€„Wõ/Öí∆.[ˆ<˛Û¸uOã›sØm◊óñ,Â˙ú®I>ÿˇ√Æôtø(!¶tÔl˜/º~KÔ0ÿ◊?uôù’ãÈ√C~∂È¯µÒd©zañ˘F4àa(#Í%∞–ª]ãÌ¡Çö˚…›¯VeÓ∆còvµu÷eÉ5x·} µ”O?áZæøˆÚÔ¯0ÿÚé˜Uj7ìú∏ˆyûBÖf0Í>66©…ô®õV¿ˆd:ˇ“ì#@pE¬Øç!ÃS?h¿ÒÉÊÛ÷b8Ç¿!“≥ÈŒWÀˇqÏ _4õ≈˛^'õ
+«Ü*m‰µüg¬kr´ƒ⁄âR©æ?çBªÈt¸Wl˚◊´¯ê„á§ã’(è2‹»on®„>7÷^#Á5∏0~Cıî ÜçµUÙ±M|ë˝ó:ØuÙË◊:∫¯k¶F›õˆsæ› çmC˛>6∂C°{∂-Ä4A$ %„®ô F’*´}òf≈=XHS?7ﬁqæ⁄=k}Æï”æ÷ïÛæó›Ó_£èú_¨úœF‹::r©S¡ÊYÊ`Á¸j‰Œ_€1b◊g¢9È◊≠ÍN€ÏW;4-_£ØkæÆ≈€π3ü 7};4>–G\Q]m…è®ˆÆ .¶Q#˛Å9ÁÛ9Ö7”ÒzÊL370w(µ ‚iö√E ªô˘⁄ÿn¢áπ∆$ã"÷Zq¥ÒÀ§z´Ω¬—!≤‡’≤π”Íº≈≈fÀ©¬õëõyÃkæõ»ÄM’…˜Õ∑Z¬AÕOïz5g2íç+8⁄¨‡xgÎjw≈\RArÏz¡ß6÷ÆÊ¿iÕÑº7ç©ÎÍÀAŸ˙⁄óÙ˚V6Êl@ë…ŸÈµ'´ ’>|ˆÿò)%¬ô ∑–˘:såB√»¡Ó∞ÿ¯VkµùÊœÑÑ∞?‰≠0ÙßÒOî8¢aüZeV÷ò⁄®„°≥wï™GıZ’Ïa>Zc≠k&†&D£i8µ±÷Ö)¥¿⁄†œû§€® HﬁX|w56®$ßsÜ‚çs¢‘ÂHßˆé£hË$¢,Ω] y˜\–∑ò§y0 Ïô{\Ë);õÊ}Â±€ÅDAµˆ5eƒÖ-_8óÉ"%T«Q∏M¬`¥rƒ-s	·◊>ª˜∂to¨gI,Éx'˚Q,lëZÒßMR@÷6Ãd‰t¢û4ú¡Öã^◊2⁄¬÷ÁO∫[!m—"ÿ1∑{=z[Æâ,W©Ë¶z‚^íÙ‚L%D¶ ª6cÍ£1UæRãBç;
+å4[·Û"∆≤Ü£äÉäu°6|¨∞BûãrnÓw5÷G˚Ó≠
+„k∆…r–ﬂ∂CíÑxüL0·Ô#ÏvC]ó4Î<P(\¶¨kôÅèÄÁÙ≥± ıh);,¬‘2LY+';#-öHÈ“¶FER∫……∆®ÄrÑ3<OÃçå∆å`éÊ-qblõV“Lö—É‡Û<êO{aÃ‰[Õ¬ÆQfeåÆÆŒAÆ¯P^à[iÖwùÈ—Fïÿv|≤JÌT`X.xWT≠TH{N„VŒ€ıULo\¥›M2=∫Cn¶ßãÊª§ªnÇ«üT∫˜ÿÏäå´ª∑°“$7‰òX/∏YP8˘ ‡€"˙<Ï†J÷‚H|◊W£sf€t+ßø·^Æ†ÜÂ.Oÿ‚˘aT1f™
+¿èÿ££ƒ%Gˆ]˘]«ı:«Å‰^_¯¸	°j	Á™|º©¸÷¸o™|˘*üOïœwïè?P˘˙ì´¸M‰ﬂ4˛M‚ÀõƒóH¸xì¯›˙Mâø)|∫+|yS¯rS¯rS¯Ú¶Â7(|S¯Ú}ÖOo
+ˇÖo
+ü®È¶ÈM·”˜˛M‡„)ı˜¸)ÔwqøI˚©Ï∫çC⁄˚$Ì˘&Ì˘M⁄˜ìB⁄ÎM⁄˚õ¥ßõ¥◊õ¥◊7iØß¥◊õ¥◊7i/?íˆSŸ€]Ÿ˚]ŸaOVi&ì8;u©ÕÚ.ÿ%◊É‹ı2kõÃÈ c∑øGó29ƒ#2)@∆⁄%)òÎTà;móêtŒC%äÚ≈ê>®ÖçûæÚ—x8AÈ`Ãö∫z"gˆı∏ae/¬‘_gƒ”∞Y0∆æ{obd¡XHT<≥∞‚=7D „àG^,‘|(†ÂsTïDêv"≈E–°0	úËΩ„ÍÅ≠eÊŒ-5óoè|FÏo)gYH*[ÎŸöÀâí–t¢JxßJÆ‡+R“Í˝TÑf>PΩoúÔπûéUågªˆûlÍÎUÕvy‹ÉÔi`
+a7ñm˜vE®´˛Ú{ö—)ÃÒjsâ>©˛»Ú†¿JÁÃ†¥‰öI‹[òo´Ù.àë«'‚}Å‘’/!ëbçY˜¸≤Ïœ›∆ñ8Õh¿⁄ı:Zhﬂtı2t€∆„O‹&^Ôî€aÍwíπÒÚ$çr&|ê¿7Âª•Œx º∂T^0|Qöá∂ïo⁄F◊¥µÕ]à˜6T˘ÊeﬁPÒBd·µn’∞Ø«^Ô8…?’æO®"„V‰ît‹áMÿ˜îÎv J´»°(∂∆ˆ˚ä4◊¶Ï¡5;ı{Peë©≤®é3\TºøweQˇïEø$≥{ä¿P{òñ@Gq‹•Ü=É~Ë√˝{WfÇØÂ{Ω'lˆ£—Ô#8n¶m‘_'ûwLk•$^ R(®ñ£ÓçÖ%jq∑„’%F≠+çDë¢=;˚83xŒ°TQ˜Ë¥e®»,>9— ØXìd
+@RùTK”€π÷∂óãrr…8eD·EΩ.Ò8a«ıSØãØ.©ã‡ªËXÜGáÑ~ªËOióKç)âG}µí;:9¿¶ÔR9ó7~mŸÙﬁIrñTY&I]¢™äòí…5ñ∆√˜h®Æ„Ä·S:kô“qÿÌëŸ;Ô√Œ|¢≤,≠„Ω¨]|§#ÑãlU¸2Ò=Û˚πÙìOÑjà °@õ≥ø)°ø»lnÄÎârﬁ+6øé*úT®w@±Ã`˘n4 	Ax∏/$])l UÁ¶ˆÿr∆˛À2Mô⁄ò◊ÎgÍCÕâﬁgπª˘ÂÂ‡ÊÃ1ík◊1,‹¥¶£Á∂∏¬Lã9Øﬁ∂—4ƒÎcªdmÈy±B§}ﬂ!£ÇwwOCyî=Œ√4wN&ÇaÊJıJãJV4‹Q&£>ºZ3Qñ„EX_g»ÚõÎ0Ω›≈àyâ8m3Æ¬W@ûV€Àô]»»!∞ŒJ≈øœç‘'úU§êÔgˇ∫ËnÊaZFh£è…ìQŸ∑Lñí“ùí€Ö¥=◊Û‘ìÂ≤‹náñu£xÜÃÊ;*FÙ§öê´d ƒÂFRl«*Ö˜u≠bt8ùNa‹W«kIªnsÓc8¨Â·f<ìñLúY@v–ûNP4û8nIâ≈[b.æñ5›kÑ5ì¸eX≥Ü€
+vk)Ì$£BëGlÙî˚;Nq&ë˙¬–±Œ6Ìú˘çûÙ›Ëâ˚Á=±ÌwuøÎÖÙÆ¬¡/y‰€ù∑t‹y∫Óº‹Ô¸vÂ˘ßΩÚﬁë≠…\I©Õ™“`“])‚Ü®ë›Õ$∏ª]ﬂ£ÀQ;Ñ¡6–˘3cÈí“2ñOq=Âu¶Ãc[.∂ì-Ú~$n°ßØ|4ˆ£ÿÍ≤v1ˆ2°Ù±—√ÜÏΩãµÌ¡F¨´ A∞wZä ™Pñ;^êQ4k%¶=Ó	∏˜5	ƒBÆÑêù(u`›G…ˆEÖû€‹	3ñ·‚WÔ-o‘±∏t'ó≈ƒ ÷˛ó˙jÌmπ¢˙ö¡è‘3Û~ ãô∂’⁄í+)m∂NQäªp‚ N∞›?ﬂˆÃÉ"á¢hôvãmÑPã√˚ò{œ=«+Wøí∆Ñûê’*‘ΩîÕ_—≠VÅÊF!Çí∞ﬁGW¯wA≥Ñ!@⁄[È1π^—ä2«µ”ûı¨ñ$ôˇ≠ˆﬂ=´¬≥4—ÿÄ,¯V>Oûsáu–°l≥vCù{;⁄äÕJÄ∂òÄÂq]˝xØÚG&Èï<ùë™™ÇJ©:°»∂cπA#–([Ò
+Ïîl∞]…¯X jÅájÛøÍ~#ë{"≠Ói[∑ø$j”˛Òæjˇ∏åÌoöÌHv›˛B•Ì{:∂ø—	lV°˝É8çø∂˙ü•˝/7xÙXˇã@‘bˇ”∞g”ˇ· Ω¶≠±]™•,[Ÿj~{µÊW.¯ı¶ƒYÂï◊°ºû"æ:7¥«Øe†.q¶ß‡=Èlºcüﬁ·s≠£Ÿ4É{˝∫2Ë⁄!®2@Ñk÷XEÕPØâÿ– 0+Ê¡»M„ l“CLT&5&Z≥°_ıä»®D™∂˘5êäƒ)tq@fpâù™x?•ÉÙ?YÇüJÿ~F˜†∫Y	yD\{$£ı7F÷±ˇÉGƒ/=R∆Ï√3YØÇJZo÷$ÃÊÆ@√i4D4∏≠Q√¥Q£<üd·ÚßÏıdI≤…“=∑8»≤ÂdÊ˙5˚5Ÿy÷ÄŒQ
+E¡‹Ω/≠
+g0Å˙ºh	oVŸÎÂ◊´/ŸO?˝¸Ûõ#•˛„!Êıä˛›Ωtı—Èù≠÷ôõI∏πC–àTYœÅL∂˙ú]Êßoœ«î‰á3wÕ‹eQ.Áo„ûO ÂÊØÒ©√1ï˘Iy^ŒVõüñøå)œó´Ú|¸∑’bNV‘ŸVÄúé Ÿ
+¿’Nò«S=ƒ†ãêl˜ÌÚeP⁄úa^+˜ª†<ø8sõœ«Ã‰øåu^ñµg¡°G|y}∏˛˛„Ínu˝œÔY˛ØènGüF_FW£Ô££o£Îq”◊ƒçD0Ø‘°È	≤§uæzª(+˚uù¥$«~TÆ$oj?ı|Oû¨
+Ù¶ø·•_ˆz-íD1Bçª¶–s(k••ÉIÂ≤îœ∆´<˘`Æ€ıËæ?‡É£=åí„I-shUÅnnZæÃ«"?è5‚éáÈ¬2'dW≤¸Ëıøåﬁ’a◊Bø6ª◊Ö≈ïo^Ìƒòî¬6iﬁ∫wª˜·û2Èßm˜∂Ì‹6€›¯Vÿ¬ç
+â=ñÿá˙l∑Îm…Äˆâù√Âj+I{w|W<ä«ó	‚ÒH‡^<µ4]ºp“ä˙ÌÁ√‚p’}◊<‡5N˛%∂¶GGge3î÷&âcAµìMŸ_!Õ?FÒπ›È¢tÛu€’ò∞6∂€ÚÌÒÒ¥«iF0‹¡nöØπÃﬂ’Õ˚tﬂøz‡ËÛùZ'TÀj6>`Üõ¸bQ¬Á&∞∑˜KGŸe+¯wÕ0õ$@9E˙tÒ”–D !lH@&
+≈˙†§¶%t´ú^ïgÂ≈È|V™ìh6pÿÇ%'÷≤V%¥—‹)VõÓqÛøÙdÂ§úM‹˜/õÈ?3öœAT¥Ã=oô∏Ãk‚2ùœÅÿ¯Å=ùœís›∫3	°áõ8e˙lÌô»ÌË~Ù•o‘!üπiÛ2?zãê≈éËû
+u&8œihÉ$¿˜ÑÀ!1ﬁxæu„áyº&5X:®VbÚtzrZ¶¯›⁄Êö¿RŸruÍmr”åÅ¬Q:5”«ç-n^”ÚÏœC<ª›ÌˆåSËD•Z≈x÷Á7Öq}ˆ¸ú]Å3~ÿÌõÄ,r™/1t8;ÍsN.‰=ﬂπﬂê∏´—∑›ÓI]"l´ßºƒ8\lÄ∆NMB®›j—=îPÇ•-%åßPNŸcC†sÎctí8ëµæ$xRÂ¸rHÜÔ^∑»Ò›#¿%-O¨]BÃ0‚Ò(ÌØá˛z÷N{˙2Eë'—r}Pq<†8÷^ˇALç~Î	@ÒBbh∑XzwÀFo˝u—ilvíµ7$JLaπí/”ó—}Oxw¡π†≠@fﬁ’˘#N2î!7-'ã,-˜='™òπ™L1	‰ùõÙ˝n‚bÿñ¸XΩ«ˇ÷û÷±O—JâC(ZM’1”˘|1¶t˚ SHPNã⁄≠ƒSs‘« Ø˚ŒW[∞&.:
+âÇ¨Î,2Úˆ–jµ´¿ÿ“∂u“ÔÜ…àp}Ns®#ÎpZ\´‡4àN} e©
+≠©yÅ~∫}Ïq]Hè≤≠|œè{”+¥„≈≠x/[}3H‹¢¬øèn˙5NÆ–6ÇMU6_ùvq∆é¡%8ﬂ_ªBPHmÒà-Ñ¢ä`‚ƒ}≠»®ˇdÎ/ıÿ√{ç¿ÑEŸRK–YB¿C=1¡˙Ó`–IL≈xÆÎ¯-QD6>çÂŒ@¯^gÕ?4ü?H_u–¥rPôvüuˆÒ9qˇø{èy†ßËUƒIÂÒÖpOAAæàµxéÈO›Ùw◊rPºj°|√§®bbõ©›ú˝É˝C≠´D2‘BàÙ∏zÙ¨l)—™\üÙ•Á∫†≠Km]ÉRˇ◊{NõB+n	˘=ñ·K˜‹Ô:ÿ'ˆ\≥˛\˝0"b˝	–7W¯É’=U{ $¶ÑAÛ‘‘|ÜÒ“÷zçMäVô‘øÀ¸µkêj‡[–.,˝ﬂ∫îŸ†ƒxU≈u¶PÃËÿöÀ’¢°ß
+§oê	≤ —é¥¬7≤O dH˛∑EJ
+4§‡6µsŸ/BíÌî/qscÍa=NÎ6≤´:¥™’2F%% C:ÇÖ
+$Ûˇ¸Ì_:Ïb‡qv@:ëƒÙíZJULÍt~^∫˙Ã^xp	„ò¨H¨ı¶åJhUÍR÷‹Òó˘‚è©©P–=O(ı¸NBÅ í∫ÅÇT–~”∆ó∂	‘PYh	4u®˜¯Vw∞L—˝∑∂gG3ã≈·∏òg√d„ÁñXi7ô5÷&Ü «"?ﬂ“$iÈK7kXÍ·∞˛Ÿø›yYuÎA˘atÉªØ=}ßÅöË0N9§WîÖó˘¢<˙j:ü-Oß]≤‡P+ô>Æ°`˛‚t>+ªKíqTn¨+ê W7µÅë÷…~®·Éˆ5N◊64”ìÈÁ∂@ı
+n†çúB¬~Å€ò1ó∆O¯Rj¸/˛LœkÅ‘∫Åç{¥‰¬7„õw»Û…n≤Úºÿ”ºì¸ïÓÈ¶08	µÖÖi˘√!¡¯ê_¬ÿf¸©¡3TÈÀå	˛%|¿œ dR≤Ω"7¿√9xUz?€√õÌ∆1ü¨˚s∆».Ù∑t3s:w]tUÔÛc∏mŸﬁ{fh3e3ê˛ÇJÊ‰È0bˆ©è;–,µ3=È#≈R†|$O∑£5Ü√=>w;ƒhÇ2µ∂úúŒÁg=>k≠£Îœ˜ÒÉ^h˜ΩW;Ω4 çQ’¥wôM/Œ∆‹ÊÛsGæü1∞∂àªc zÁ)Ï˝Ú]Q«øBÏ)ŸË‚õõBÖF≠#_-∆†øGΩ¥CZt`kÎ∞CZÉs|Ûå„#˛Ø=˚ÿÕì)¥ÂÚ§ÑœÏ‚x:Å"…◊(áöpœ\øÇ√Ë |Æ—™=ÙN;x…ÄFØ≥1„äç—|~vVûÙ&ÿIÄã[Ø@qæ'úÖÄÀlêL∏ﬂÈπffª˘ºø}‰^Ú¸¿Óu9uîtw^çpﬁ•Y…è ìEô0¿g˜‘´!•YAà≈·\ªªπΩ¡È"Áts√·0~@˘≠—7˝]ÉC4T ƒ"ƒÓr>ôvµJ[¯Ã€v¯=®ƒ üwzI)Ü∑!*µ≥Ïì§ÁO∏ËŒ˝ãW€hØö÷b(¯Wˆ∏I^>èµZ,î*’õß"B≠-≠ˇüN"àŸÓ∆u◊E=dﬁG&oÊÖ¡≠}5¡tk–á‡Ïx5ÃÕÙ° Â:e8q:xå´8}~`“Â"^£±ÿEŸ˛…1Z:“Iºë–Â˝|vTÓó<©±@y≠“åá 54ﬁëK„\"5nﬂ‘7 R√ˇ¯jÇêZ0«…f(’ì‘¡‰aÇühe}Ç O‘t¨4WÂ—Ú≠÷≥,É<÷H≠tÇ1Å∏`ZIì∆…àkF&Põ˙;Ë‚Ë•Æ&x{1aÇ©´Í&˙F•_∞°ª(¨Ô¯Ω•>ZìI∏2-aM©\<ÃV´«≈Û›Sv(Ibd≠J†º9©7 §·n~sß5Éüô¥eó¢ﬁK¡tëNä4∆<ÛHîaJ%6%çÒÙß#©J∆íõj_~f—í^˝7—Wu‡µ±Y1\•√jôDZœ1…ö[Å]§≥Èôé§nÙî˚“'Û“él ÈÎõtÂz$m–Ô∞á6≠r"~äﬂÌ9ä,ä11Âú7»
+Æ’√ù/∂üƒ4fàá÷©¬0OÒKÑä&HØ=Ñ¥N˙Ñp= ÙñøÇ—Åcz›±ä·9Ûä˙ X«ıB¿ f∫ˆ!vÓXC∫‡±Pm å—xendstreamendobj153 0 obj<</AntiAlias false/ColorSpace 137 0 R/Coords[0.0 0.0 1.0 0.0]/Domain[0.0 1.0]/Extend[true true]/Function 152 0 R/ShadingType 2>>endobj137 0 obj[/ICCBased 82 0 R]endobj152 0 obj<</Bounds[]/Domain[0.0 1.0]/Encode[0.0 1.0]/FunctionType 3/Functions[92 0 R]>>endobj92 0 obj<</BitsPerSample 8/Decode[0.0 1.0 0.0 1.0 0.0 1.0]/Domain[0.0 1.0]/Encode[0.0 63.0]/Filter/FlateDecode/FunctionType 0/Length 206/Order 1/Range[0.0 1.0 0.0 1.0 0.0 1.0]/Size[64]>>stream
+Hâ ¿ ?ˇˇˇˇˇ˚˜ˇ˜ÚˇıÌˇÚÈˇÔÂˇÌ·˛Í‹˛Ëÿ˛Â‘˛„–˛‡Ã˛ﬁ…˛‹≈˝Ÿ¡˝◊Ω˝”π˝—µ˝œ≤¸ÃÆ¸ ™¸«ß¸≈£¸¬ü˚¿ú˚æò˚ªï˚πë˙∂é˙¥ä˙±á˙ØÑ¯¨Å¯™}¯®z˜•w˜£t˜°q˜ünˆúkˆöhˆòeˆñbıì_ıë\ıèYıçUıãRÙàOÙÜLÙÉHÛÅEÛBÛ}?Û{<Ûx9Úv6Út3Úq0Úo.Òm+Òj(Òh&Òe$ …^ã£endstreamendobj82 0 obj<</Filter/FlateDecode/Length 2574/N 3>>stream
+HâúñyTSw«o…ûêï∞√c[Ä∞ê5laëQIBHÿADEDÑ™ï2÷mtFOEù.Æc≠÷}Í“ı0ÍË8¥◊éù8GùNg¶”ÔÔ˜9˜wÔÔ›ﬂΩ˜ùÛ †'•™µ’0 ç÷†œJå≈b§	 
+  2y≠.-;!‡í∆K∞Z‹	¸ãû^êiΩ"L ¿0ˇâ-◊È @8(îµrú;qÆ™7ËLˆúy•ï&ÜQÎÒq∂4±jûΩÁ|Ê9⁄ƒ
+çVÅ≥)gùB£0ÒiúW◊ï8#©8w’©ïı8_≈Ÿ• ®Q„¸‹´Q j@È&ªA)/«Ÿg∫>'KÇÛ »t’;\˙î”•$’∫FΩZUn¿‹Âò(4Tå%)Î´îÉ0C&ØîÈò§Z£ìiòøÛú8¶⁄bxëÉE°¡¡B—;Ö˙ØõøP¶ﬁŒ”ìÃπûA¸om?ÁW=
+ÄxØÕ˙∑∂“- åØ¿ÚÊ[õÀ˚ 0Òææ¯Œ}¯¶y)7taææııı>j•‹«T–7˙üø@Ôºœ«t‹õÚ`q 2ô± ÄôÍ&ØÆ™6Í±ZùLÆƒÑ?‚_¯Ûyxg)Àîz•è»√ßL≠U·Ì÷*‘uµSkˇSeÿO4?◊∏∏cØØÿ∞.Ú Ú∑ Â“ R¥ﬂÅﬁÙ-ïí25ﬂ·ﬁ¸‹œ	˙˜S·>”£V≠öãìdÂ`r£æn~œÙY†&‡+`úÅ;¬A4à… ‰Ä∞»A9– =®-†tÅ∞l√`;ª¡~påÉè¡	Gp|	ÆÅ[`LÉá`<Ø "AàYAê+‰˘Cb(äáR°,® *ÅTê2B-–
+®ÍáÜ°–nË˜–QËt∫}MA†Ô†ó0”alª¡æ∞éÅS‡x	¨Çk‡&∏^¡£>¯0|>_É'·á,¬G!"F$H:Ràî!z§ÈFëQd?r9ã\A&ëG»îàrQ¢·höã —¥ÌEá—]ËaÙ4zùBg–◊¡ñ‡E#H	ã*B=°ã0HÿI¯àpÜpç0MxJ$˘D1ÑòD, VõâΩƒ≠ƒƒ„ƒKƒªƒYâdEÚ"Eê“I2íÅ‘E⁄B⁄G˙åtô4MzN¶ë»˛‰r!YKÓ í˜ê?%_&ﬂ#ø¢∞(Æî0J:EAi§ÙQ∆(«()”îWT6U@ç†ÊP+®Ì‘!Í~ÍÍmÍçÊD•e“‘¥Â¥!⁄Ôhü”¶h/Ë∫']B/¢ÈÎË“è”ø¢?a0nåhF!√¿X«ÿÕ8≈¯öÒ‹åkÊc&5Sòµôçò6ªlˆòIa∫2còKôMÃAÊ!ÊEÊ#ÖÂ∆í∞d¨V÷Î(ÎkñÕeãÿÈlªóΩá}é}üC‚∏q‚9
+N'ÁŒ)Œ].¬uÊJ∏rÓ
+Ó˜wöG‰	xR^Øá˜[ﬁo∆úchûgﬁ`>b˛â˘$·ªÒ•¸*~ˇ ˇ:ˇ•ÖùEåÖ“bç≈~ãÀœ,m,£-ïñ›ñ,ØYæ¥¬¨‚≠*≠6Xç[›±F≠=≠3≠Î≠∑Yü±~d√≥	∑ë€t€¥πi€z⁄fŸ6€~`{¡v÷Œﬁ.—Ng∑≈Óî›#{æ}¥}Ö˝Ä˝ßˆ∏ëjááœ˛äôc1X6Ñù∆fmìçé;'_9	úrù:ú8›q¶:ãùÀúúO:œ∏8∏§π¥∏ÏuπÈJqªñªnv=Î˙ÃM‡ñÔ∂ m‹Ìæ¿R 4	ˆ
+nª3‹£‹k‹G›Øz=ƒï[=æÙÑ=É<À=G</z¡^¡^jØ≠^óº	ﬁ°ﬁZÔQÔB∫0FX'‹+úÚ·˚§˙t¯å˚<ˆuÒ-Ù›‡{÷˜µ_ê_ïﬂòﬂ-Gî,Í}ÁÔÈ/˜Òø¿Hh8m†W†2p[‡üÉ∏AiA´ÇN˝#8$Xº?¯AàKHI»{!7ƒ<qÜ∏W¸y(!46¥-Ù„–a¡aÜ∞ÉaÜWÜÔ	øø@∞@π`l¡›ßYƒéà…H,≤$Ú˝»…(«(Y‘h‘7—Œ—äËù—˜b<b*bˆ≈<éıã’«~˚L&Y&9áƒ%∆u«Mƒs‚s„á„øNpJP%ÏMòIJlN<ûDHJI⁄êtCj'ïKwKgíCíó%üN°ßdßß|ìÍô™O=ñß%ßmLªΩ–u°v·x:Hó¶oLøì!»®…¯C&13#s$Û/Y¢¨ñ¨≥Ÿ‹Ï‚Ï=ŸOsbs˙rnÂ∫ÁsOÊ1ÛäÚvÁ=ÀèÀÔœü\‰ªhŸ¢Û÷ÍÇ#Ö§¬º¬ùÖ≥ã„oZ<]T‘Ut}â`I√ísK≠óV-˝§òY,+>TB(…/ŸSÚÉ,]6*õ-ïñæW:#ó»7À*¢ä eøÚ^YDYŸ}UÑj£ÍAyT˘`˘#µD=¨˛∂"©b{≈≥ Ù +¨ Ø:†!kJ4Gµm•ˆtµ}uCı%ùóÆK7YV≥©fFü¢ﬂY’.©=b‡·?SåÓ∆ï∆©∫»∫ë∫Áıyıáÿ⁄ÜçûçkÔ5%4˝¶mñ7ülqlioôZ≥lG+‘Z⁄z≤Õπ≠≥mzy‚Ú]Ì‘ˆ ˆ?u¯uÙw|ø"≈±NªŒÂùwW&Æ‹€e÷•Ô∫±*|’ˆ’ËjıÍâ5k∂¨y›≠Ë˛¢«Øg∞Áá^yÔkEká÷˛∏Æl›D_pﬂ∂ıƒı⁄ı◊7Dmÿ’œÓoÍøª1m„·l†{‡˚M≈õŒnﬂL›l‹<9î˙O §[˛ò∏ô$ôêô¸öhö’õBõØúúâú˜ùdù“û@ûÆüüãü˙†i†ÿ°G°∂¢&¢ñ££v£Ê§V§«•8•©¶¶ã¶˝ßnß‡®R®ƒ©7©©™™è´´u´È¨\¨–≠D≠∏Æ-Æ°ØØã∞ ∞u∞Í±`±÷≤K≤¬≥8≥Æ¥%¥úµµä∂∂y∂∑h∑‡∏Y∏—πJπ¬∫;∫µª.ªßº!ºõΩΩèæ
+æÑæˇøzøı¿p¿Ï¡g¡„¬_¬€√X√‘ƒQƒŒ≈K≈»∆F∆√«A«ø»=»º…:…π 8 ∑À6À∂Ã5ÃµÕ5ÕµŒ6Œ∂œ7œ∏–9–∫—<—æ“?“¡”D”∆‘I‘À’N’—÷U÷ÿ◊\◊‡ÿdÿËŸlŸÒ⁄v⁄˚€Ä‹‹ä››ñﬁﬁ¢ﬂ)ﬂØ‡6‡Ω·D·Ã‚S‚€„c„Î‰s‰¸ÂÑÊÊñÁÁ©Ë2ËºÈFÈ–Í[ÍÂÎpÎ˚ÏÜÌÌúÓ(Ó¥Ô@ÔÃXÂÒrÒˇÚåÛÛßÙ4Ù¬ıPıﬁˆmˆ˚˜ä¯¯®˘8˘«˙W˙Á˚w¸¸ò˝)˝∫˛K˛‹ˇmˇˇ ˜ÑÛ˚endstreamendobj186 0 obj<</Metadata 91 0 R>>endobj91 0 obj<</Length 11047/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.1-c037 46.282696, Mon Apr 02 2007 18:36:42        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+         <dc:format>application/pdf</dc:format>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xap="http://ns.adobe.com/xap/1.0/"
+            xmlns:xapGImg="http://ns.adobe.com/xap/1.0/g/img/">
+         <xap:CreatorTool>Adobe Illustrator CS2</xap:CreatorTool>
+         <xap:CreateDate>2006-05-22T16:29:31-07:00</xap:CreateDate>
+         <xap:ModifyDate>2006-05-22T16:29:36-07:00</xap:ModifyDate>
+         <xap:MetadataDate>2006-05-22T16:29:36-07:00</xap:MetadataDate>
+         <xap:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xapGImg:width>256</xapGImg:width>
+                  <xapGImg:height>64</xapGImg:height>
+                  <xapGImg:format>JPEG</xapGImg:format>
+                  <xapGImg:image>/9j/4AAQSkZJRgABAgEBLAEsAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABABLAAAAAEA&#xA;AQEsAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAQAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9U4qxnzl+YGi+WIeM5+s&#xA;ag4rFZRkcqdmc/sL/mBmHqtbDCN95dzstB2Xk1J22j3/AI5vOF1781POsjfoxXstPJI5wH0IgPeY&#xA;/G58Qp+jNT42p1H07R+X2vQnTaHRj1+qfnuflyCIj/I7X7n97qOsRCY9aCSY/wDBNwyY7Imd5SH3&#xA;tZ9o8UdoQNfAfraf8mfNunEzaPq8fqrv8LS2zn5FeQ+84D2VlhvCX6FHb+DJtkga+ElO38+/mJ5R&#xA;uUtvMlq93anZTPTkQOvp3CVVj/rcsEdbqMBrILH46spdmaTVR4sJ4ZeX6Y/2PU/LPmrRvMdj9b02&#xA;XlxoJoH2kjY9nX9RGxzdafUwyxuLzOs0WTTy4Zj3HoU3y9xHYq7FXYq7FXYq7FXYq7FXYq7FXYq7&#xA;FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWM/mB5yh8saKZ1o+oXFY7KI9OVN3Yfyp/QZh63VDDC/4j&#xA;ydl2XoDqclfwjn+PNgX5ffl9N5gmPmbzMXuIrhzJBBId5z/vyT/I/lXv8uus0OhOU+Jk3v7Xedqd&#xA;qDAPBw7Ecz3eQ8/xzZx5+tvNi6HbxeUh6UscqiWOH00YRBTQJyooAalQP1VzZa2OXgAxOl7MngOU&#xA;nUbiut80ps/Inna9gjuNY813lvcuoaS2tD6YQkfZ5RuqtT2XKIaPNIXPJIHycrJ2lpoEjHhiR3y/&#xA;aFz+TPzA02s2j+apLxlqfq2oKXVh1pzYy/qHzwnS54bwyX/W/BQO0NJk2yYRHzj+A3p/nGHUbg+V&#xA;/O+mJY384Cosg5W09dhwYk8ST9khjv0NdsYaoTPhZo1I/Irl0Bxjx9NPiiP9MPx+AwzzR5b1b8vN&#xA;dg1zQ5GbTXfiOVSFqamCWh+JWA2P8RXNfqMEtLMTh9P42LuNHq8evxHFlHr/AB6g9f8ALmv2WvaP&#xA;b6nZmkcw+KM/aRxsyN7g/wBc3uDMMsBIPJ6vTSwZDCXRMsucZ2KuxV2KuxV2KuxV2KuxV2KuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KvEteWTzr+ai6ZyJ0+ycwPQ7CKDeY/N3qoPyznc3+Eanh/h&#xA;H6Ob2emI0eh4/wCOW/xPL5B6Hb+ftBXzUvlKGCWOeL9zHIFUQhkj5cBvyoFFOn4b5tY62Hi+EAb+&#xA;x0E+zMpwfmCRR38+aXfmP+Y48uhdN01Vm1iZQxLDksKt0JHdj+yv0n3p1+v8L0x+v7nI7J7J/Meu&#xA;e2MfaxO3/Lv8x/MSC+1nVGtjL8aQzyOXFen7pPgj+X4ZhR0Ooy+qcq9/6naT7V0enPDjhddwH38y&#xA;l0X5e/mBp/mq0jg9WUQSIYdTVz6Sx1BYkk/CBvVO/gcqGhzxygDp1ciXamkyYJE0LH09b/HV6p5m&#xA;0zyz5qtp9Elu7d9Rh5NEEkRp4JAPtcAeQH8wObrUY8eYGBI4vtDzGjzZtMRlAPAfLYhJPKFzJ5j8&#xA;vap5T8xfFqOnE2lyx3Zk39KUE9WVl6+wPfMfSy8XHLFk+qO36i5mugNPlhnw/RP1D9IY5+T+oXek&#xA;eZtS8rXhpyLlU7CeA8W4/wCsgr9AzD7LmceSWI/gh2PbuKOXDHPH8A/t+97Fm/eRdiqVeavMVp5b&#xA;8vX2t3al4LKPmYwaF2JCogJ6cnYLioeRD86PzLsbSz8yaz5ct4/KV7IqRyxFhNwapVgTKxqVGxaM&#xA;K3alcFs+EPb4J4riCOeJuUUqq8beKsKg/dhYMG8x+dtZ0780fL3li3WE6bqkDS3JZSZeS+rTi3IA&#xA;f3Y7YEgbM8woSfzh5kg8teWdQ1ydPUSyj5LFWnN2YJGte3J2AxSA8cH5pfnBpunWfnDVtPtpfK17&#xA;IoFsiqrLG5+EghjIvL9lmqPvGC2VB7rZ3cF5ZwXcB5QXMaSxN4o6hlP3HCwebfml57866J5m0XQ/&#xA;K9vbXNzqsbFYp13aQNQAMXjUbeJwFkA35F/MzzRcebG8n+dNLj03WniM1pJCfgkCryK05yqfhVm5&#xA;K9NiKY2pD07CxeMan+Yf5oeYvMesWfkWzhXTtAkaK4eZUaSd0ZloPUI+2UPFVFfE74LZUGb/AJW+&#xA;e385+Wv0hcQLbX9tM1tewpXh6igNyQNUgMrDY9DXEIIpEfmb5k1Hy15H1LW9OEZvLT0PSEylk/eX&#xA;EcTVAK/sue+EqAmnlXUrjVPLGj6nchRc31lbXMwQUXnNErtxBJoKtigppirsVdirsVdirsVdirxr&#xA;8jo/rOv6xqMu8wiAr7zScm/4hmg7IFzlI933vX+0Z4cUIDlf3D9rI/Itjb33nbzVrNzEslzbXptb&#xA;WRgCYxHzjYr4EqqjMrRwEs2SZ5iVB1/aWQw02HGDsY2fPkWM/l3bR+YvzH1TWb4eqbZpJ4Ubejl+&#xA;EW3+QnT6MxNDHxdRKcum/wCp2Paszp9HDHHa6H2b/Mpr5z85+brzzcfK3lYiGWEUkkHDnI/D1G+K&#xA;TZVUfTXLtVqsssvhYnF7P7P08NP4+fcH37b10TD8sfOuuapqF/oOvAPqVgGb1eKq37txHIjhKLVW&#xA;YUIy3s/VznIwn9UWjtjs/FjhHLi+iX6RYYLoeg3OhfmvZabdz+pJHcchcITVw6F1Jr/NWjD55rcO&#xA;E49UIk9Xd6nUjNoZTiOceXx/FM+ZRYfnMnpVC6tpvKYdi6Eiv3QDNp9Or2/ij+PudEDx9nb/AME/&#xA;x97GdZQ2H54WssXw/WZoCQP+LohE/wB++YeUcOtBHUj7qdlpzx9mEHoD9ht7Lm/eQdirAvz2/wDJ&#xA;Va5/0a/9RkOApjzRfl3VvLFj+X/leLX7yytYp9LszDHfyxRq5S3j5cRKQG48hWnSuKll8LQtCjQl&#xA;WhZQYylCpUjbjTalOmFDybzr/wCT88m/8wsn/M/B1ZDk9cwsWBfnt/5KrXP+jX/qMhwFMebEfOP/&#xA;AKzdp3/MLp//ABNMeiRzeqeT/wDlEtE/5gLX/kyuFBeU/nPqd3pf5l+UNQs7GTUrm2jd4rCHl6kr&#xA;cz8K8VkNfkpwFI5IHyhr2peafz0tdS1+0bQr2wspEsNLmSRZWXg44kuiEnjPI9SB02xSeT3vCweJ&#xA;/lB5i8v6R5g88Lqup2mntNqjGIXU8cJcLJNXj6jLWle2AMimH/OODK3l/XWUhlbVHII3BBjTELJP&#xA;/wA9v/JVa5/0a/8AUZDiUR5p/wDl/wD8oH5b/wC2XZf9Q6YVKfYodirsVdirsVdirsVeM/ky507z&#xA;bq+jzHjL6bLv3e2l4kfcxOc/2UeDLKB/FPX9vjxMEMg5X/ugyfyZINN/MDzVo8x4vdyrqFtU7MHJ&#xA;Z6V6/wB6OngczNIeDPkgeu/4+bre0B4mkw5B/COE/j4MF8gR+adP/MEQQ2ksAlmZdSgKH01hqSas&#xA;R0Xqp77eOa3RDLHPQFb7+53faZwZNJZIND0nz/HNm3nX8stR1PXP09oF+LDUnCibkzx/Eq8A6SRh&#xA;mU8RQimbHV9nynPjgeGTpuz+2IY8XhZY8UPgfsKJ8keSIPJsF7q+r3qS3kqH6xcVIjjjB5N8TULF&#xA;iASSMnpNIMAM5ndr7R7ROrMceONRHIdSWJ+Tnl82fmpc+YEQixtC0qlh0UJ6MCnrRj9qnscwdKTn&#xA;1JydB/YHaa8DS6EYv4pfrs/qTvRtZ0/zH+bkl5aPWDTbB4YmYUMjLIVYqPD98cycWWOXVWOUY/j7&#xA;3D1Gnnp9Bwy5znfu2/Ykd4/6W/PGJYiWS1nQVHb6rDyf/h1IzGkePW7dD9wc3GPC7MN/xD/dH9T2&#xA;fOgePdirBPzyjkk/KzXFRSzAW7EDwW6iZj9AFcBTHm8z/MW98pan+S3le4S6gn1jT7e1tLZFlPqx&#xA;t6SJdKYg3jCKll27ddwWQ5vedCVk0PTkcFWW2hDKRQgiMVBGSYPLvPc8EH57+TpZ5FiiS0flI5Cq&#xA;P78bk7YOrIcnq1rqem3blLW7huHUcmWKRXIHSpCk4WLDfzyjeT8rNcVByIFuxA8FuomY/QBgKY82&#xA;CecNX0xv+cddJgW6iaaaGzgjjVgWMkLK0i0HdApr4Y9GQ5vYfKaPH5V0aN1KuljbKynYgiFQQcLA&#xA;vNvzLmhh/OLyNLM6xxIHLyOQqgcz1J2wFkOSHvtT0/V/+cjdBk0ueO8isdOliu5YWDoj+ldEgstR&#xA;t6yA+5pj1Xo9mwsXgf5aeQfKXmrzF50k16w+uPaam6259WaLiHlmLf3TpWvEdcAZkp//AM43RpH5&#xA;d1yNBRE1N1UeAESAdcQiTIPz2/8AJVa5/wBGv/UZDiUR5pn5A1nSB5K8uQG+txONNskMXqpz5+gg&#xA;48a1rXamFSyrFDsVdirsVdirsVdirxXz7Bc+UfzEtfMltGTa3b+uQNgWpwuI/mynl/ss57WxODUD&#xA;IOR3/W9j2ZKOq0hwy+qO3/En8dzLPOFhcahFpfnfyuRcX9iokCKK+vbNUslOtVqw49dz3pmdqoGQ&#xA;jmxbyH2h1egyjGZ6bPtGX2S/H6E60zzNbeavLN3Lok/o6i9vIgiZgJIJ2QhOXsG3DZkY9QM2MmB9&#xA;VfIuHm0Z02YDKLhY9xDybQtE/NjQ7me702yuY5JCUuA/CQOa1qVcnlv+0PvzR4cOqxkmIL1Op1Gg&#xA;zARnKPlz/HwTd/J35qebJUTzBcm0sQwYrKyBR7rBD1YduVPnl50upzn94aj+OgcQa/Q6UXiHFL4/&#xA;ef0PT/K/lfTPLmmLYWCmlec0z7vI52LMR+Azc6fTxxR4YvN6zWT1E+Of9iUazbeVPJVnqPmO2s44&#xA;L+dWVTViZJZDyVFUkhQWFW4gbD2yjLHFpxLIBUi5ennn1ko4TImI+wd/9rE/yV0S5uLzUPM97Vnm&#xA;LQwSN1d3bnM/30FfnmD2TiJJyH8d7tPaHURjGOCPTc/oD1rN48q7FVO6tba7tpbW5iWa3nQxzQuA&#xA;yujCjKwPUEYq8/svyD/Li01VdQW0mlCOJI7OWZngUg1Hwn4mA8GY4KZcReiYWLEvOP5XeVPN19Be&#xA;6zHM89vF6MZilMY4ci24A8WwUkF3k78rvKnlG+nvdGjmSe4i9GQyymQcOQbYEeK40pLKLy0tb20m&#xA;tLqJZra4Rop4XFVdHFGUjwIOFDzqw/5x9/Luz1ddREVzOkbh47CaUPbgjcAjiJGA8Gc174KZcRel&#xA;AU2GFixTzl+Wflbzfc29zrMczy2qGOIxSGMcWPI1oPHGkgq3k/8ALnyl5R9V9Gs/TuJxxlupWaSU&#xA;rWvHk32V9lpXvjSkslxQkflvyZonl251O501ZFl1ab6xeGRy4MlWb4a9BVzikl3lPyZonlW2ubbS&#xA;VkWK7mNxMJHLn1GAU0r0FBipKJ8y+XdN8x6Jc6Nqau1ldcPVEbcG/dyLItGH+UgxQGG2H5Cfl7Y3&#xA;1ve28NyJ7WVJoiZ2I5xsGWop4jBSeIvRcKHYq7FXYq7FXYq7FUo81+WbLzHo0um3XwlvjgmAqY5R&#xA;9lx+ojwyjU6eOWHCXL0Wslp8gnH4+YeS+W/NGu/l5q0mh65A76azcqLU8QSR6sBNAyt3H6jXNHg1&#xA;E9LLgmPT+Nw9Vq9Hi1+MZcR9f42kzO58oeXvMcg8xeU9UOnai+7XNofgZjuRLFVWVj+109wc2EtL&#xA;jy/vMUuGXeP0h08Nfl048HPDjh3S/QXI35y6fSLhpurqD/fEmNyPehgH4Yj83Hb0y/HwUjs6e/rh&#xA;+PigtZ0b83PMenvaXklhpsBozRQvIrSEdFLKZtvpyvLi1WWNHhiPx727T6jQaefFHjmfOtvuT221&#xA;mz8leVLO28x6is9/BGaqrGSWQliVVFajEKCF5Gg27ZkxyjT4gMkrkHCnp5azPI4Y1En4D3/e84A8&#xA;xfmh5iBINpo1ofmkKHrvtzlen+YzU/vNZk7oD7P2vQfuezcP87JL7f1APbNN06z02wgsLOMR21sg&#xA;SJB4DufEnqTnQ48YhERHIPG5ssskzOW5KJybW7FXYq7FXYq7FWK/mj5gv/L/AJE1XVdPdI76FEW3&#xA;d6bNLIsZYBtiyqxKjxxKQkH5PRareW0muP5kv9W064iWD6lqMXB47lQrSOrF3+Hcgcdt+ppgCSmG&#xA;qatqU35v6JottdSR2Nrptxf39sjERyeoTBH6g6Hi1CMUdGbyOEjdyQAoLEseI2Fdz2woeJflVrHm&#xA;XzfrY1ObzPfRXdrO8+oaT6IbT2tywVIYnDcK+9K/SORAZHZm/wCa2t6xZabpWlaLcmz1LX9Rh09L&#xA;tRVoopK+pIvuNvv8cSgJn5P8r69oUt6NQ8w3Gt2s/D6rHdqDJCVHxH1OR5cielNqDCpLEfzHs9dm&#xA;8/8AlvTdN8w6hYLrrTLPbW0vCOKK0jDs6AD7TVO5wFIZl5jupfLvkLUJxcyT3Gm6dII7uZqyySxw&#xA;lUd2/nd6E++FDyr8pfMPmXVPN2lxW2t6jqtmti83mWK+H7mGV0PpLCzfETzK9twCakdAGRZ7+aus&#xA;61bWmjaNol2bHUdf1CKy+uKvJ4oCCZZE912+jEsQgPyym16Dzf5u0S71i51nTtJe0W2uLw8pBJLG&#xA;zOob2pQj2rtiElLvzO8+6noH5i+XIIJ5E0q2jFzrUSH92YLmYW3OUdDw6rXoT74lQNmQ/lHqupaz&#xA;oWpaxe3Mlyl9ql29jzYssdsrBUjTsFBVqUxCCt8satqep/md5tjN1I2k6THaWlvalj6XrSJzkcL0&#xA;5AoRip5ITzrda/rPn7S/J2l6rPpFqLKTU9TubSgnKCT0o1Dn7PxD8d67YpDLfKmkavpOjpY6rqr6&#xA;zdRuxF7KgRyhPwq27VKjuThQXlGq655mu/zQvNI1LzLd+V2+sRR+XrcQcrO5i5U+I8lDNJ25bcjx&#xA;r0XAno9vwsUs1/y3o2vWZtNTt1mQbxv0dD4o43H+dcpzYIZRUg5Om1eTBLigaeYah+UHmfR7s3nl&#xA;bUi9PsqZDbzgdePIURx86fLNNPsvJjN4pfoL0uLt3Bljw54/ZY/WPtWJrP54WB9KW1mueOwJgim/&#xA;4eIb/fiMutjsQT8B+hJ0/Zk9wQPiR9617z88dWrEsU9qjGhokNrT/Ztxf7jgMtbPbcfIJGPszFvY&#xA;l85fsRuifkreXFz9d8z6gZnY8pIIWZ3c/wCXM+/zoPpyzF2SSbyH8e9p1HtDGMeHBGvM/oD1HTtN&#xA;sNNs47OwgS2toxRIkFB8z4k9yc3OPHGAqIoPM5c08kuKZslE5NrdirsVdirsVdirsVYt+Y/kuXzd&#xA;5fXTYLwWVxBcR3cErIJULxcgFdD1U8sSkFGeUtE1/S7Sf9N60+s3lzJ6pcxJDFEKU9OJFrRfp+gb&#xA;4qWOa15B83y+drzzPonmCHTpLq2js1iltBcFYk4sVqzU3kXl0wUtstvtIn1Dy1caPeXRae7sntLi&#xA;9RQpLyxGN5VQbDc8gMKGL/l/5C8z+W3hj1HzGb7TbKFrez02GBIYuJbkJJDuzMPv/wAo4Ekov8wf&#xA;JWqeYpNIvtI1JdM1XRZ2ntZZIhKjFwAQwP8Aq+BxKgpx5W0jWNL01odX1eTWb2SVpZLqSNYlXnT9&#xA;3Gi14oO2/wDTCpQd35SkufP1j5okuV9GwsZLSGz4Hl6srktJzrSnA0pTFbVfPnlq58zeVL7Q7e6W&#xA;ze9Eam4ZDIFVJFdhxBX7QWnXFQUHo3kb9E+dr7zBbXK/U72xgs2suHxB7YIiSGStD8CUpTAtqP5g&#xA;eSNW8w3Wjalo+prpuqaJLJLbPJEJo29YKG5Ke44bbHqcSoKJ8heS5fLNpfNeX7anq2qXDXeoXzII&#xA;w8hFAFQE0A/z8MKkpfrn5Zx6zrXmHULy7Vo9Z01NMtovTJNvxIfnUt8X71Q9KDBS2nnkjyyvljyr&#xA;p+hLMJ/qSMGmC8AzO7SMeNTT4nPfCpKH8neUZNAuNcup7kXVzrWoS3zMqcAiPThFuWrw33xUlJfM&#xA;35e+ZLzzi3mTy/r40ia5sxYXYe3WdhEG5ExciADsNttxWuClBZppVnPZabbWk91JfTQRqkl3NT1J&#xA;WUULNxAFThQ8+f8AKvzJqPmCwuvMPmZtU0nSbs31jbNbpHOXLBwkki0+EFR0HToF7CmVv//Z</xapGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xap:Thumbnails>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xapMM="http://ns.adobe.com/xap/1.0/mm/">
+         <xapMM:DocumentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</xapMM:DocumentID>
+         <xapMM:InstanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</xapMM:InstanceID>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="r"?>endstreamendobj149 0 obj<</BaseFont/SZKDGN+MyriadPro-Regular/Encoding 147 0 R/FirstChar 27/FontDescriptor 148 0 R/LastChar 151/Subtype/Type1/ToUnicode 88 0 R/Type/Font/Widths[307 284 284 523 523 212 0 0 0 0 0 0 0 0 0 0 0 207 307 207 343 0 0 0 0 0 0 0 0 0 513 207 0 0 0 0 406 0 612 542 580 666 492 487 646 652 239 0 542 472 804 658 689 532 0 538 493 497 647 558 846 571 541 553 0 0 0 0 0 0 482 569 448 564 501 292 559 555 234 243 469 236 834 555 549 569 563 327 396 331 551 481 736 463 471 428 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 207 354 354 0 0 1000]>>endobj147 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[27/hyphen.cap/parenright.cap/parenleft.cap/f_l/f_i]/Type/Encoding>>endobj148 0 obj<</Ascent 952/CapHeight 674/Descent -250/Flags 32/FontBBox[-157 -250 1126 952]/FontFamily(Myriad Pro)/FontFile3 87 0 R/FontName/SZKDGN+MyriadPro-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 88/Type/FontDescriptor/XHeight 484>>endobj88 0 obj<</Filter/FlateDecode/Length 535>>stream
+Hâ\îÕéõ0Ö˜<Öó3ãÏ{	EJìéîE‘LÄÄì"5ÄY‰ÌÎ„É&£"Åè¡ˆ˘|‡ín˜ª}ﬂÕ&˝9Õ¡œÊ‘ıÌ‰Ø√mjº9˙s◊'´‹¥]3/Ωxm.ıò§aÚ·~ù˝eﬂüÜ§™L˙+<ºŒ”›<m⁄·ËüìÙ«‘˙©ÎœÊÈ˜ˆl“√mˇ˙ãÔgìôı⁄¥˛˙VèﬂÎã7iúˆ≤o√ÛnæøÑ9èÔ˜—õ<ˆWÑiÜ÷_«∫ÒS›ü}Re·XõÍ-Îƒ˜ÌœE9Ìxj˛‘SR≠æÑ¡YñÔ÷Ao©KËı+Ù◊®E¬πEˇÌ—«ÿ<„ÿzY„Ú›cÌúkÑ&hŒMRe‘÷)6‘hé)0∆Æ¢M–9ΩsËÇ˜hKm°µÉjÅVjÖ~•∆˛,,,ÛM–‹ã≈^,˜b±ÀΩXÏ≈í”Ç”1á989898989úéúúéú
+NGNN«¨≤Ê#»G>Â#Ù¯
+}æB_ÅØ»Ú.°È+˙
+|ÖæÒ]}%˙2+AV¬¨‚˜!ÃJêï,ﬂ≤íÂªAV ¨Y)˘¸J~øí_¡Ø‰W+˘¸˙)7%øÇ_?Â¶‰W+˘¸%ºÚlÖ˚eA˛“RÉøTjãi©îU®~ÛQ≥ÕmöBπ∆_D¨STh◊˚èø»8å&Ã¬ô¸` 8ãÈendstreamendobj87 0 obj<</Filter/FlateDecode/Length 4804/Subtype/Type1C>>stream
+Hâ|TyTSWèG^¬‚CHü%…ò¡Í0EîEDGP,Óä⁄∫I Q÷à‡T±ä ´À°≈Qd±¢ÄJ±"Udd\(»R•£VÎ˜‚≈„º‡å3ÕπÁ‹wøﬂ˝ñﬂ∑‹ác∆Fé„¢Ä/W{-˜˘|MºF-W¯i"g˘+Cc√‰√%√ p÷⁄òùfN#Gî˘ˆÌ[o‘Y¿êÂè¯ƒŒ
+„„∏ôhÜù}Û}U|îJ·,èäíkîu®J˚Q
+SÜL!€¬B∂©øàåäü∏ó9Õô3«ﬁ∞ª»&>s=ë€ï≤Ä¯≠2<F∂2"8R©ëkï
+ôgXòÃﬂ`#ÛW∆(5qpΩCÄÉÃèSà– º\Ê∫ÿœusr¯êäL#ìÀ4 P5ÁM£T»¥πB.◊ÏîEÜ»˛O§ŸÀ÷≈G)en2Ö2√pnaõD`bìaòç ≥ÁaŒlâScò√ax≤1Ê≈’[É˘aXñè’a=¯<g¥¬Ë*aB)D±±©±≥ÒJ„Ω∆Ÿ<Sﬁfﬁyí C…ü»ü˘÷|˛èÇOkZ¡ê…:ìlSc”ç¶9füôÌ0À7{inoæ»º⁄¸˝$œIÁ(L’Ro-ñZÏµx:y—‰‹…mñ§ÂKÀÌñG-oXôZyØK´c«Ípnü^G§≥)zøÒ2Q#ç<‡FI$C◊h0„G˘„‰÷â3x N&Ÿz⁄pBâBœ(Ωá/É?£z:—+⁄6vm√Î≥µó +x$†>è√Û¿ëËC&ÙŸÀ’@Ù€Ì≥N\%ãÛP(æi∆K ç(Åz§5Û©D∞¬Î¡å "ëÆ,8SQS§Ri¢CB£ 
+©Ùû:<û-¡4ú”´yÀIT˙NÕ£‰˚Ó¡Çªpı.^5 9Oàg˚ËS©g”K∑k+©ª*∏s˚ s∞√Ç˘Ä!9!Y ‚û3ò4◊UWH3…Ωa˛Aä’WqÑßƒ⁄ï! ∂ò©rEƒ◊)˚Óg⁄-~íE_ﬁx0r≠•õ·ÿZ¬Æèå·©År9Sô™=£í®4Q!*ÎtÙ˚Gº»ÄG¿)d«Ÿ≥)ùV`fvÔ1üDÏ=Êíà	GÖΩ	ÎË‘”)?Ø©Æ]i8_◊*ÓŸ–Å¯Åªc‘“Boﬁ…”æ´ê4•ñ™7ä∑j[◊K7˘≈˚	Ãà∂éV¢mAˇSøoúäU+¥˜¶È¨N≥∑ÑΩÏBP—ùH≈„öû†wÂŸê(˛ù+oàlÔD+›x¬—øV}[ï}AêAf+≤És∑µ†@kjOR+‰¥@Ã]´ûà\1"|›ìA'◊&ﬂîÄQO˛•ÀLŸπÇÍFÒÛ≈◊VófÖlG—•Õ‚kqTE“2y@Æãƒ«7iøí£3s
+2/HoÜ-\µ˛´ŸÃBr•q')|˝¥O9€Œmácò&=3Å°N'v≥µ]·:´äa[4L'®÷'Jêõ˝Ô0ñæ~Nó˜Ó>«+OuÑmﬂiOÃì %≤ÂV(ä[4	¸ﬁ…;^ P@$µ≥ó⁄û÷lò‡∏¨ÆOπ-ÅO_ï551M∑ÀÜ¿H∏ÍæÔuÈu?ßbd)YÊù¥?êXM.(À™ëÄ˜–‰ú †U3lëèzgzV¨îÚNÎÇ‰NPwqé	÷ùµ¶Q.®°§k{Á Zt°HÜ\íZŒµ¢±¥z=S†éu¢c†Ö‚.Ùû§ÜtBd;Ì
+3§Àö˜«ÿü·ç4Ka*⁄BÓ”)ˆ˚Kê„Ù∞‹ﬂº∑÷ö=ª+·CÍc9>yÓá§h&⁄í ÿT86HΩ[Gøî˜‰|œPcÉ∂(◊q†oêË—ª“Ô\†˙P€†ﬁ’ï£>(ÁS®ÌTúﬁU7AÙÉéﬁïOÌ˘/»±œ&ÔtÉ=Ê˝F¢„¨5§¿˜<Ñëh;:í-JÅ˚.$Âñ÷≈˛˙o+÷¨U±ør(ddÅ…Ã8ˆÒÄU£ﬁK•∑õ“O πyDâÃQOXÓ„ô∞\êB&¥kª#!>ÙYs∑¬®Õ‹º>"O¿≈#//„±(É<˘Á3.•ˆa%‡®õ◊BrÔÎe#g˚˙DôdÍº#àwxñÄ˙-Há8ˆŒÓ1Ù<ÑßÖõ¡i
+TÒÖa`|Ë¡¡~ifzŸíèÀãE∞=Âq%ôè IaûM∆¸cé“C©;€õ˙D(~·ŸøsÂ“'v∞?t‡£Ï#º‘{“h˜∑ë°(,ëñ¡bòÿåÃ`ÚfíΩh¯¨ùS£YÓH»ık™;–0˛ÿ	"òŒPZÆMyÌPlòTH˙PÌÚ`~ajë§ˇﬁÈ´µLY˘â+∑ƒ7cØÜîJ+ÇΩÛÁJñÆK: gºÈ¨‹‚ÃÛígMAN´7⁄Dƒdﬁ≈P	ú«ö8z˜<÷<$˚R*T˘'ÁÂ˙´ë_Ìné˝ew{ÿï'ô¸é¬ÜüûàÎw’™K§ÁÂæy_ÔÉﬂlc|Ë¨úí¨ãíë‘&•ãÿ√o£É‘â§÷$v±W:wË¨!¸â∞˜‚9:¶¢C◊,Áﬁ·Wˇ\{ë’åC≈ˆø7âkÀØè‹™—Ì˝õTXS»Õno^¯¶„À$ËSw˚V0R0√™äPoÒÚõù|˝ÛRjÌ©8v¨á†AÇ¶≤c∞Ω{<Ÿ‰$5¬ı‡≠ø7›Éƒ=n^«ßÒëÚ’Bê¬¿˚!X Nu∑Â#ª’+g:Æ¯ÕU‘DûÖ'ªÓljóÆ0ôÙV˜(•‡≠Í(85
+Ç®∞8ÂrT@ÂhúUH¿uêp*(√‚»oEπ5:*(<@á]kÊ5ıc´ˆ,ˇÌ™˜Ω˜˚æ˜Ω˜∫ñ0ºùHúì˝jì•°mr˘ÎT,òl·ÓøÂ$"ëŸ“~NáW+›≠¥‰ëgÒœΩû#“e$ƒ‚ﬁÉ1{ U¡˜˝˜Q—tµŒ€æÉµøb¥®«–ãÁfﬁÊBÔ2óÙA˙öÑ åÎH:¢qÇ*P¨Qz®=1l∆É#É ¡Ø·≠t%π
+ç':+\9Ø/µdz˜ë·‰aWòêÆ aÉ%]ÒGﬂU•BæŸ}Ô!Ü{rråMâQF|©!è‘*´„çé‡(]HÇô±'à_…!p®πs∫ˆt=6IYd˘˜5˛f¥H*VÑf≥◊D†‡ø »≈»/nW‚Â\à¢5π1Æc)¯IH80#%PΩH¨≈nÆ0	ŒÛúº-œôf˛îCÚV|qm&x#º’àfÊŒ	ÒFÆ;JŸù Ó∂©É∞™ç_Ìí…}S»¡oGJ\sfQ^›ZÿBøœˇ&ÇÕ°m:;d-˚∂}”/˝W´Î*ÒÇ¶T'˝àAÚÿ%mcìlu´Ñj;™Õ–e¬’æÙÓΩï∑&@PÚNÀäπÅΩ
+ﬁ} ¢ìmL£P;Fµô‡/J™ïk£òüI™-wê»!}jo∆–Ã‡…ÇΩnıØËs⁄=``´Ö[Œ‰Ëåß§0«†?≈ÙñﬁlºKO¥Ø]åÑÛX·≥´©3Ö’û“ÊÁÀƒ_·ñ˚l@P˜R»€K∏¯®¥ z…7˝0gÍÓs^πƒ•ó±g˙CBH¡w4r\ÄoèE»·≠=,ÏÓ(1úe≈y‹ÉHøæﬂRo›K®¬ıÚˆ”r	j“äÍìÇj<i4◊ﬁπËXdˇ ¨ü›iº^…Ë1#πkàg§ÊRV[≥å.rö…ï®≥“5È’Êùπù^<ÙÀÔ◊_˜\		(`s8ùäìâπ~pªv˜u√ê?"‰√A!—ÂÈKe/√ÄEéhû°Öh·KXÙ‰ZI·FuüPGÌÂ|ißmG-´ª/È<Yˇ¸%˝˛ús@>fp_Ú.Ω∞ÓÅ‡˘®‹my∞ÓE÷?âùÓy\Qz¸XcË#N¶ƒûå°√˜§EG±·ë™≠õeâõΩ˙f\D‚\¥∑Ê˜¬t?7KB≈(ﬁx)AB›—◊Îkòı$5ôπë–íä#^Î¬Øñ£µHf^ ü?æZ€R…ÍI$ˆ˛˚™mA•g¢ô$/"ÆæK}õÓÏ+4∂≤≠MÂ} î9√_%*m q†îƒ¸<{sÓ>Ój€UÃÊ¶Î“T2q6~À:VC`nLh≤É≤DWp¬¿\)ni∏Eø®Úvg—Ö1º.¿’ÆaKTLÜ*éâU%%©„≠¥p√â£GEô¸ÿ‹¡¢1j\ly•”åRDMß◊H¢bñ'\®)?w>ãΩ†8≈àQ7⁄◊?MŒFô>FÌC˚$≠]≈ııl≥±®sB∆ouöY"BVG#bE‚~.BcEM¡∆È€í(åx®,˛RMYE’,b4#vô≠≤[∞.Œ∏´úˇ'Ö-dK;∏"Ò;â@lÉ`bâÊ#WuJä"=[^å‚¡ ∑ê`a`Zé1úÎC,ë…Õc¶ÜL∂fÃNëæËDc,l0ﬁ†{´÷≥®ŸWE≈9≈π¶π®˛r;˝†:`9ã*ÕP'∑•M>!—ÈIáòdïR°ä≈3ñ"®¡õv›Àj∞E3üÎ…ú]x–'E,i-ÇPO,ä-9sÛô∂¢ñ∆€Xë-Xëãc–$Çuv^ÆªC-Iµ$‹?·„z¯π=ÿ™–˙J¯$H6o)ZçñM-Å/¿˛¸6É√≤)ƒ≤Zo…áFªØë¿◊mçãﬂ‡ooZﬁ}¿≥}´Äm˝ºpÄ˚4\&MH.Öb=\uÛp‰ofÿˆNÔëµõˇ˛Ì˚X\∆PÊ¬ç‘áËÉ∂ FC$ÜúÇú|ÜöÏ)πŸ|óÔ∞Ãï¿À}w6u¶≤⁄|≠°@&˛q6’ ˇáÓ”\ò‰ÌqÆ1˛ﬂ∞]◊§od÷b[h,∂hM∫ÏA/@÷Æ»ŸøYƒ”ÎuW~bı$àÁ§iR2”ød˘~zq»;‹xÚ∫ß5$pv(®”eb§ƒØ|¡%ˇÀÚ,™”ÑØÇ|Ãp°ﬁ¿Ùå≠˜hC^ñ6è•
+^à®N˝ˇ–e–€wÜoIb3I™JÛ÷¢’nù‹#9}$˘⁄0»FÑıg%…’mÍk4àz:GÜ6≠π»˙û;T⁄ ´≠:µ•&5˝4SﬁE«Ü i;_˜ç¡£1lwBEbò,‚`¥œûê“í8ÏåDŒ–+7«˘â£á◊cT"Úœ≠àc .©ÈÍ û,a3{àÃ4µ6ÅñßTﬂe°lzëXâƒôú)‹bõÅ1PçQ-|<Øî8°v2Uìz<çâLﬂNªæ˜ÜÖ2'T+BÎ_á˝lÓË®?kô¥ nƒSRSóelóâ=≥«ºf°
+¯›Tl∆ﬂ%1LÇ?Ø$VêÀPæR˜®#∏|≤f4§5§óBÖTﬁŸ√pgü
+•”‘ÂRKËB:H>Ö¸ÀRrµ®›püˇ¬‡í¿G(U:H¬JåÍLnBô©˛iª~ê„œµ©;é‹ˆÄ„RO“e•ÓL˝é≥|?⁄û÷ÆæÓYRÒ
+|Êe'√©d¡è¸6a±%”ZîÅ<P61âˇÔ•U%ˇ◊Ïï¿ñ¿úºŸÛÚ/˝fîxœˆ€Ó{∞/U«™√ÊÆR]X]Tù4µzYÕí enü%¯Ãï˝‰.gúÚ#öy
+»H˜?A¨˝Ω-mRm-ÌMrÂqπô≈Ö•yµ•-%ˆoõµm„Ò˝€ú˙nı]‚˚[	=6ÌﬂÍ3”öÚÄeLÛä˙ç´øoí‡˚-‹}Ò˚ÎKås»2œ˚!{Ò˜˙^∂ÖKÊ/ûøÏ{Œ˜µ=áXˇ∞∫|ü’…VZX^RV¯;ˇ˜F†ÆÿüNÂåkøÔc˛.¯#Nt⁄Â•ünï»èM¯ÕPbŒÒΩy*B∞ 6˛7C©9HóH◊^Ê?ÌD\
+îÀOîX∂s€wÜE˜8é6≈
+ïKë≈¯~~/9Œ∏ÚóÛ ÔD˝9vçzæü=√∏Ú{7Û |¢^ﬂªœ ≈[˛<Ã¯]Ì
+ÛcK—”Œ}˛!ı=“„ªà˜]9w∂Àã¸vó˙ÌÚ[ÃEC™˛ÙUÊÔ·?E}Ã=~ãt˝é‰¯~˛∑»)πl.ÔCæã|wì˙Óy‡ªÿï∑r|Ÿê™÷ˆ<∞™˝´mYœ˝f]Ã~sÂπÁkµ5œí˚+ÚËß+˚¸Ù∞È¡“ëUŸ©Úq…%˛Re–
+7©¬Fòˆ«Ù—èäﬂk≥ﬂXvÊ≈∂çu5‰ñúcù[63N˙∑åÉ≈o˘B®	”~öMˇ7Ìª˛¥=”˛îLb˚·5Ò∑œƒ?˘”vL\1ë]nAÇk”Ãˇ<úÁ∏s?ÓÁ·˝û,Úcø(@Ä ≠	˚^endstreamendobj138 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj100 0 obj<</DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 650.07 269.52 668.79]/Subtype/Widget/T(Name_Last)/TU(LAST)/Type/Annot>>endobj118 0 obj<</AP<</N 63 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.24 650.07 578.88 668.79]/Subtype/Widget/T(Address_1)/TU(STREET)/Type/Annot>>endobj101 0 obj<</DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 625.95 269.52 640.59]/Subtype/Widget/T(Name_First)/TU(FIRST)/Type/Annot>>endobj119 0 obj<</AP<</N 64 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.24 626.43 578.88 640.59]/Subtype/Widget/T(Address_2)/TU([1])/Type/Annot>>endobj102 0 obj<</AP<</N 23 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[26.8802 601.95 173.52 616.35]/Subtype/Widget/T(Name_Middle)/TU(MIDDLE)/Type/Annot>>endobj103 0 obj<</AP<</N 24 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[183.6 601.95 221.52 620.67]/Subtype/Widget/T(Name_Suffix)/TU(SUFFIx)/Type/Annot>>endobj104 0 obj<</AP<</N 25 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[231.6 601.95 269.52 620.67]/Subtype/Widget/T(Name_Prefix)/TU(PREFIx)/Type/Annot>>endobj120 0 obj<</AP<</N 65 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 601.95 452.88 620.67]/Subtype/Widget/T(City)/TU([2])/Type/Annot>>endobj121 0 obj<</AP<</N 66 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/Ff 4194304/MaxLen 2/P 22 0 R/Rect[462.6 602.19 482.88 620.91]/Subtype/Widget/T(STATE)/TU(STATE)/Type/Annot>>endobj122 0 obj<</AA<</F 164 0 R/K 165 0 R>>/AP<</N 67 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[491.28 602.19 578.88 620.91]/Subtype/Widget/T(ZIP)/TU(ZIP)/Type/Annot>>endobj105 0 obj<</AA<</F 158 0 R/K 159 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 529.83 143.16 548.55]/Subtype/Widget/T(Telephone_Home)/TU(HOME)/Type/Annot>>endobj106 0 obj<</AA<</F 160 0 R/K 161 0 R>>/AP<</N 26 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[153.24 529.83 269.52 548.55]/Subtype/Widget/T(Telephone_Work)/TU(WORK)/Type/Annot>>endobj123 0 obj<</AA<</F 166 0 R/K 167 0 R>>/AP<</N 68 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 529.83 578.76 548.55]/Subtype/Widget/T(Emergency_Phone)/TU(PHONE)/Type/Annot>>endobj124 0 obj<</AP<</N 69 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 505.59 452.4 520.47]/Subtype/Widget/T(Emergency_Contact)/TU(NAME)/Type/Annot>>endobj125 0 obj<</AP<</N 70 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[462.48 505.59 578.76 524.31]/Subtype/Widget/T(Emergency_Relationship)/TU(RELATIONSHIP)/Type/Annot>>endobj107 0 obj<</AA<</F 162 0 R/K 163 0 R>>/AP<</N 27 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[26.8802 432.99 269.52 451.71]/Subtype/Widget/T(SSN)/TU(SOCIAL SECURITY NO. \(MANDATORY)/Type/Annot>>endobj128 0 obj<</AA<</F 168 0 R/K 169 0 R>>/AP<</N 77 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[433.32 436.95 503.88 455.67]/Subtype/Widget/T(Birthdate)/TU(MONTH/DAY/YEAR)/Type/Annot>>endobj126 0 obj<</AP<</D<</MALE 72 0 R/Off 73 0 R>>/N<</MALE 71 0 R>>>>/AS/Off/BS<</W 0>>/F 4/MK<</CA(l)>>/P 22 0 R/Parent 7 0 R/Rect[336.12 439.95 343.2 447.03]/Subtype/Widget/Type/Annot>>endobj127 0 obj<</AP<</D<</FEMALE 75 0 R/Off 76 0 R>>/N<</FEMALE 74 0 R>>>>/AS/Off/BS<</W 0>>/F 4/MK<</CA(l)>>/P 22 0 R/Parent 7 0 R/Rect[336.12 427.83 343.2 434.79]/Subtype/Widget/Type/Annot>>endobj108 0 obj<</AP<</D<</Off 30 0 R/On 31 0 R>>/N<</Off 28 0 R/On 29 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 388.59 33.4802 395.91]/Subtype/Widget/T(HIGH SCHOOL DIPLOMA)/TU(HIGH SCHOOL DIPLOMA)/Type/Annot>>endobj109 0 obj<</AP<</D<</Off 34 0 R/On 35 0 R>>/N<</Off 32 0 R/On 33 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 376.47 33.4802 383.79]/Subtype/Widget/T(TRADE CERTIFICATE)/TU(TRADE CERTIFICATE)/Type/Annot>>endobj110 0 obj<</AP<</D<</Off 38 0 R/On 39 0 R>>/N<</Off 36 0 R/On 37 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 364.35 33.4802 371.55]/Subtype/Widget/T(COLLEGE NO DEGREE)/TU(COLLEGE -NO DEGREE)/Type/Annot>>endobj113 0 obj<</AP<</D<</Off 50 0 R/On 51 0 R>>/N<</Off 48 0 R/On 49 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 352.11 69.4802 359.43]/Subtype/Widget/T(ASSOCIATES DEGREE)/TU(ASSOCIATEêS DEGREE)/Type/Annot>>endobj114 0 obj<</AP<</D<</Off 53 0 R/On 54 0 R>>/N<</On 52 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 339.87 69.4802 347.19]/Subtype/Widget/T(BACHELORS DEGREE)/TU(bACHELORêS DEGREE)/Type/Annot>>endobj129 0 obj<</AP<</N 78 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Sig/P 22 0 R/Rect[335.353 332.67 575.797 351.39]/Subtype/Widget/T(EMPLOYEE SIGNATURE)/TU(EMPLOYEE SIGNATURE)/Type/Annot>>endobj116 0 obj<</AP<</D<</Off 57 0 R/On 58 0 R>>/N<</Off 55 0 R/On 56 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 327.75 69.4802 335.07]/Subtype/Widget/T(MASTERS DEGREE)/TU(MASTERêS DEGREE)/Type/Annot>>endobj117 0 obj<</AP<</D<</Off 61 0 R/On 62 0 R>>/N<</Off 59 0 R/On 60 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 315.63 69.4802 322.83]/Subtype/Widget/T(PROFESSIONAL DEGREE)/TU(PROFESSIONAL DEGREE)/Type/Annot>>endobj111 0 obj<</AP<</D<</Off 42 0 R/On 43 0 R>>/N<</Off 40 0 R/On 41 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 303.39 33.4802 310.71]/Subtype/Widget/T(PHD)/TU(PH.D)/Type/Annot>>endobj112 0 obj<</AP<</D<</Off 46 0 R/On 47 0 R>>/N<</Off 44 0 R/On 45 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 291.27 33.4802 298.59]/Subtype/Widget/T(OTHER DOCTORATE)/TU(OTHER DOCTORATE)/Type/Annot>>endobj44 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj45 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj46 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj47 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj40 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj41 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj42 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj43 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj59 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj60 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.04 re
+f
+endstreamendobj61 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 39/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏  û}Ûendstreamendobj62 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 61/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏@®¬Pœ¿BLòÍö	à
+Ä   +∂endstreamendobj55 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj56 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj57 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj58 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj156 0 obj<</BaseFont/Helvetica/Name/Helv/Subtype/Type1/Type/Font>>endobj157 0 obj<</Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 160/Euro 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]/Type/Encoding>>endobj78 0 obj<</BBox[0 0 157.56 18.72]/FormType 1/Length 12/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC
+EMC
+endstreamendobj52 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/FormType 1/Length 80/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</Font<</ZaDb 115 0 R>>/ProcSet[/PDF/Text]>>/Subtype/Form/Type/XObject>>stream
+q
+1 1 5.32 5.32 re
+W
+n
+BT
+/ZaDb 4 Tf
+2.138 2.306 Td
+3.852 TL
+0 0 Td
+(n) Tj
+ET
+Q
+endstreamendobj115 0 obj<</BaseFont/ZapfDingbats/Name/ZaDb/Subtype/Type1/Type/Font>>endobj53 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/FormType 1/Length 30/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0.749023 g
+0 0 7.32 7.32 re
+f
+endstreamendobj54 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/Filter/FlateDecode/FormType 1/Length 107/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</Font<</ZaDb 115 0 R>>/ProcSet[/PDF/Text]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ2P0P0◊36ÇE©\i\Ö\Ü
+Ü
+¶ æ)T0ú+®2ùÀ)ÑK?*—%I¡D!$çÀHœ–ÿB¡Hœÿ¿L!$ÖÀXœ¬‘H!ƒl&êØëß©í≈Â¬»` 5@Üendstreamendobj48 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj49 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj50 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj51 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj36 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj37 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.04 re
+f
+endstreamendobj38 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 39/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏  û}Ûendstreamendobj39 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 61/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏@®¬Pœ¿BLòÍö	à
+Ä   +∂endstreamendobj32 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj33 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj34 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj35 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj28 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj29 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj30 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj31 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj7 0 obj<</DA(/ZaDb 0 Tf 0 g)/FT/Btn/Ff 49152/Kids[126 0 R 127 0 R]/T(Sex)/TU(SEx)>>endobj74 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter/FlateDecode/FormType 1/Length 78/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ*‰2T0 BCc=S ab°êúÀe®gnÖ1Ù,Õ°$TL%sÈ"	Í"©Ö≤A* rPaTY]®)»¢» ·Ü§qr ó=âendstreamendobj75 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter[/FlateDecode]/FormType 1/Length 130/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+HâtèK
+Ä0D˜9E.êí‘˙È1<É†+ﬁclâ)§aÊ1L4Õ•j¯†ãå’üÒê∆‚£,ºù‘~e,ñjŒòp:HD	¨ s¢{êøÆ %™CvZIˇ€öﬂ”⁄ˆ%’…0·¥œªQãΩﬂÛxêøÆ %™Cû∂∑  *-Bendstreamendobj76 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter/FlateDecode/FormType 1/Length 88/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ*‰2T0 BCc=S ab°êúÀ¶†C=K##(	ïÅ(‰“E‘ER´UTëÉ
+£ ÍBMAEV7$ç+ê ¿  !»endstreamendobj71 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter/FlateDecode/FormType 1/Length 76/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ*‰2T0 BCc=SëúÀe®gnÖ1Ù,ÕÕÕ`TL%sÈ"ãÍ"+ár@j í0q4y]®I(¬(:‡•qr «p!ïendstreamendobj72 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter[/FlateDecode]/FormType 1/Length 130/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+HâtOAÄ ªÔ|`Àq·æ¡DO¸ˇEdÉ â!°£Ìö¬$k‚%∏éÛÒ.P\ı:n(»ŒO)∆•ÇijÏYÏÌh∆ÏQ±Úìéñ4–√F:a˛oÌI§¥÷Åí»V¡¥πQœbo∑á˛Ï+?ÈhI=l¥†Øı+¿ ¨hE≥endstreamendobj73 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter/FlateDecode/FormType 1/Length 86/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ*‰2T0 BCc=SëúÀ¶†C=KSS#ïÉ(Â“E’EVÆUTëÑâ£…ÎBMBF—7(ç+ê ¿ 7&#^endstreamendobj77 0 obj<</BBox[0.0 0.0 70.56 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj168 0 obj<</JS(AFDate_FormatEx\("mm/dd/yyyy"\);)/S/JavaScript>>endobj169 0 obj<</JS(AFDate_KeystrokeEx\("mm/dd/yyyy"\);)/S/JavaScript>>endobj27 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj162 0 obj<</JS(AFSpecial_Format\(3\);)/S/JavaScript>>endobj163 0 obj<</JS(AFSpecial_Keystroke\(3\);)/S/JavaScript>>endobj70 0 obj<</BBox[0.0 0.0 116.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj69 0 obj<</BBox[0.0 0.0 116.28 14.88]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj68 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj166 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj167 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj26 0 obj<</BBox[0.0 0.0 116.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj160 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj161 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj158 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj159 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj67 0 obj<</BBox[0.0 0.0 87.6 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj164 0 obj<</JS(AFSpecial_Format\(0\);)/S/JavaScript>>endobj165 0 obj<</JS(AFSpecial_Keystroke\(0\);)/S/JavaScript>>endobj66 0 obj<</BBox[0.0 0.0 20.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj65 0 obj<</BBox[0.0 0.0 116.76 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj25 0 obj<</BBox[0.0 0.0 37.92 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj24 0 obj<</BBox[0.0 0.0 37.92 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj23 0 obj<</BBox[0.0 0.0 146.64 14.4]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj64 0 obj<</BBox[0.0 0.0 242.64 14.16]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj63 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj17 0 obj<</Names[(˛ˇ ~ i c o n + C o m m e n t + 2 5 5 : 2 5 5 : 0 - E N U - 0)80 0 R]>>endobj80 0 obj<</BBox[0.0 0.0 20.0 18.0]/Filter/FlateDecode/Length 326/Resources<<>>/Subtype/Form/Type/XObject>>stream
+HâLë1nÂ0DØ¬¢dâRõfÅrÇ ïÇ¸$pö4{˝•8îc|¿ˇçLár¢?$ˆKÙÛ∞«'%nâ˛—Aœv˙eGÈÂ5—ënôîk¶Ôï5ìtñLÁF“8w‡§¡IW:Ìo≥.Ÿ∏q*®9©∞¶Õ¬ΩÅ≠∞¡€…GN∞\‘ä!ã¢Oî[ÅpF®3RB!|tÉ›vﬁw<ÈÉûlˇáπv]áÿ‚·¢pısõ≤QƒL 
+è’f ·‚ËŸdø8=È~gl÷Ë€K≠≠–·1¬Àyﬁ√Æﬁ„@8ó+Ω§î’LÎÕKhãÍÑõÌx•Oq≥»‚*2z˜≈£¸¶˜y—·1¬Àyﬁ√ﬁ“wNuáwˆå C6i›…Ì€uT*˝N!s? Œu√I •¢q£˚m1$™}6\Á-‚˛` „Å£Üendstreamendobj8 0 obj<</BaseFont/Helvetica-Bold/Encoding 10 0 R/Name/HeBo/Subtype/Type1/Type/Font>>endobj9 0 obj<</BaseFont/Helvetica/Encoding 10 0 R/Name/Helv/Subtype/Type1/Type/Font>>endobj10 0 obj<</Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 160/Euro 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]/Type/Encoding>>endobj18 0 obj<</CreationDate(D:20090414174258-07'00')/Creator(Adobe InDesign CS3 \(5.0.4\))/Keywords(forms, flat, fillable)/ModDate(D:20140306175729+01'00')/Producer(Adobe PDF Library 8.0)/Subject(PDF forms)/Title(Example of an Interactive PDF Form)/Trapped/False>>endobjxref0 1960000000001 65535 f
+0000000002 00000 f
+0000000004 00000 f
+0000000612 00000 n
+0000000005 00000 f
+0000000006 00000 f
+0000000019 00000 f
+0000068806 00000 n
+0000074597 00000 n
+0000074691 00000 n
+0000074780 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000022378 00000 n
+0000074041 00000 n
+0000075972 00000 n
+0000000079 00000 f
+0000000016 00000 n
+0000022336 00000 n
+0000022431 00000 n
+0000073484 00000 n
+0000073299 00000 n
+0000073114 00000 n
+0000071992 00000 n
+0000070994 00000 n
+0000068003 00000 n
+0000068162 00000 n
+0000068356 00000 n
+0000068571 00000 n
+0000067200 00000 n
+0000067359 00000 n
+0000067553 00000 n
+0000067768 00000 n
+0000066405 00000 n
+0000066560 00000 n
+0000066750 00000 n
+0000066964 00000 n
+0000060867 00000 n
+0000061026 00000 n
+0000061220 00000 n
+0000061435 00000 n
+0000060064 00000 n
+0000060223 00000 n
+0000060417 00000 n
+0000060632 00000 n
+0000065602 00000 n
+0000065761 00000 n
+0000065955 00000 n
+0000066170 00000 n
+0000064705 00000 n
+0000065066 00000 n
+0000065272 00000 n
+0000062465 00000 n
+0000062624 00000 n
+0000062818 00000 n
+0000063033 00000 n
+0000061670 00000 n
+0000061825 00000 n
+0000062015 00000 n
+0000062229 00000 n
+0000073855 00000 n
+0000073669 00000 n
+0000072928 00000 n
+0000072743 00000 n
+0000072432 00000 n
+0000071679 00000 n
+0000071493 00000 n
+0000071307 00000 n
+0000069782 00000 n
+0000070053 00000 n
+0000070381 00000 n
+0000068898 00000 n
+0000069171 00000 n
+0000069499 00000 n
+0000070662 00000 n
+0000064536 00000 n
+0000000081 00000 f
+0000074138 00000 n
+0000000083 00000 f
+0000032837 00000 n
+0000000084 00000 f
+0000000085 00000 f
+0000000086 00000 f
+0000000089 00000 f
+0000048198 00000 n
+0000047594 00000 n
+0000000090 00000 f
+0000000093 00000 f
+0000035523 00000 n
+0000032418 00000 n
+0000000094 00000 f
+0000000097 00000 f
+0000000244 00000 n
+0000022305 00000 n
+0000000098 00000 f
+0000000099 00000 f
+0000000130 00000 f
+0000053201 00000 n
+0000053643 00000 n
+0000054084 00000 n
+0000054313 00000 n
+0000054540 00000 n
+0000055469 00000 n
+0000055717 00000 n
+0000056707 00000 n
+0000057629 00000 n
+0000057880 00000 n
+0000058127 00000 n
+0000059601 00000 n
+0000059821 00000 n
+0000058375 00000 n
+0000058623 00000 n
+0000064988 00000 n
+0000059108 00000 n
+0000059350 00000 n
+0000053417 00000 n
+0000053861 00000 n
+0000054767 00000 n
+0000054985 00000 n
+0000055225 00000 n
+0000055973 00000 n
+0000056231 00000 n
+0000056462 00000 n
+0000057241 00000 n
+0000057433 00000 n
+0000056980 00000 n
+0000058858 00000 n
+0000000131 00000 f
+0000000132 00000 f
+0000000133 00000 f
+0000000134 00000 f
+0000000135 00000 f
+0000000136 00000 f
+0000000139 00000 f
+0000032286 00000 n
+0000053087 00000 n
+0000000140 00000 f
+0000000141 00000 f
+0000000142 00000 f
+0000000143 00000 f
+0000000144 00000 f
+0000000145 00000 f
+0000000146 00000 f
+0000000150 00000 f
+0000047204 00000 n
+0000047333 00000 n
+0000046648 00000 n
+0000000151 00000 f
+0000000154 00000 f
+0000032322 00000 n
+0000032140 00000 n
+0000000155 00000 f
+0000000170 00000 f
+0000063268 00000 n
+0000063343 00000 n
+0000072305 00000 n
+0000072367 00000 n
+0000072178 00000 n
+0000072240 00000 n
+0000071180 00000 n
+0000071242 00000 n
+0000072616 00000 n
+0000072678 00000 n
+0000071865 00000 n
+0000071927 00000 n
+0000070847 00000 n
+0000070919 00000 n
+0000000171 00000 f
+0000000172 00000 f
+0000000173 00000 f
+0000000174 00000 f
+0000000175 00000 f
+0000000176 00000 f
+0000000177 00000 f
+0000000178 00000 f
+0000000179 00000 f
+0000000180 00000 f
+0000000181 00000 f
+0000000182 00000 f
+0000000183 00000 f
+0000000000 00000 f
+0000022822 00000 n
+0000000000 00000 f
+0000035485 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000023073 00000 n
+trailer<</Size 196/Root 20 0 R/Info 18 0 R/ID[<6F185C876244254CBA5693F8CDC7D0AA><07680517B50641EC873DCF06D522F846>]>>startxref76241%%EOF3 0 obj<</Length 21616/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c015 81.157285, 2014/12/12-00:43:15        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stMfs="http://ns.adobe.com/xap/1.0/sType/ManifestItem#"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmpMM:InstanceID>uuid:c39cada3-3682-2b43-86f0-ce007556145c</xmpMM:InstanceID>
+         <xmpMM:DocumentID>adobe:docid:indd:5235ff14-294b-11de-919f-d8c16f47bc75</xmpMM:DocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>5235ff13-294b-11de-919f-d8c16f47bc75</stRef:instanceID>
+            <stRef:documentID>adobe:docid:indd:87ea89f9-0d9e-11db-8dd1-d4ba47cf2fcb</stRef:documentID>
+         </xmpMM:DerivedFrom>
+         <xmpMM:Manifest>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stMfs:linkForm>ReferenceStream</stMfs:linkForm>
+                  <xmpMM:placedXResolution>72.00</xmpMM:placedXResolution>
+                  <xmpMM:placedYResolution>72.00</xmpMM:placedYResolution>
+                  <xmpMM:placedResolutionUnit>Inches</xmpMM:placedResolutionUnit>
+                  <stMfs:reference rdf:parseType="Resource">
+                     <stRef:instanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</stRef:instanceID>
+                     <stRef:documentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</stRef:documentID>
+                  </stMfs:reference>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpMM:Manifest>
+         <xmp:CreateDate>2009-04-14T17:42:58-07:00</xmp:CreateDate>
+         <xmp:ModifyDate>2015-06-24T10:12:33+02:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2015-06-24T10:12:33+02:00</xmp:MetadataDate>
+         <xmp:CreatorTool>Adobe InDesign CS3 (5.0.4)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4AE0Fkb2JlAGQAAAAAAQUAAilI/9sAhAAKBwcHBwcKBwcKDgkJCQ4RDAsLDBEU&#xA;EBAQEBAUEQ8RERERDxERFxoaGhcRHyEhISEfKy0tLSsyMjIyMjIyMjIyAQsJCQ4MDh8XFx8rIh0i&#xA;KzIrKysrMjIyMjIyMjIyMjIyMjIyMjI+Pj4+PjJAQEBAQEBAQEBAQEBAQEBAQEBAQED/wAARCAEA&#xA;AMYDAREAAhEBAxEB/8QBogAAAAcBAQEBAQAAAAAAAAAABAUDAgYBAAcICQoLAQACAgMBAQEBAQAA&#xA;AAAAAAABAAIDBAUGBwgJCgsQAAIBAwMCBAIGBwMEAgYCcwECAxEEAAUhEjFBUQYTYSJxgRQykaEH&#xA;FbFCI8FS0eEzFmLwJHKC8SVDNFOSorJjc8I1RCeTo7M2F1RkdMPS4ggmgwkKGBmElEVGpLRW01Uo&#xA;GvLj88TU5PRldYWVpbXF1eX1ZnaGlqa2xtbm9jdHV2d3h5ent8fX5/c4SFhoeIiYqLjI2Oj4KTlJ&#xA;WWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+hEAAgIBAgMFBQQFBgQIAwNtAQACEQMEIRIxQQVRE2Ei&#xA;BnGBkTKhsfAUwdHhI0IVUmJy8TMkNEOCFpJTJaJjssIHc9I14kSDF1STCAkKGBkmNkUaJ2R0VTfy&#xA;o7PDKCnT4/OElKS0xNTk9GV1hZWltcXV5fVGVmZ2hpamtsbW5vZHV2d3h5ent8fX5/c4SFhoeIiY&#xA;qLjI2Oj4OUlZaXmJmam5ydnp+So6SlpqeoqaqrrK2ur6/9oADAMBAAIRAxEAPwCbeU/KflW58q6L&#xA;cXGi6fNNNp9rJJJJaws7u0MbMzM0ZJJJ3OKpt/gzyf8A9WHTf+kOD/qnirv8GeT/APqw6b/0hwf9&#xA;U8Vd/gzyf/1YdN/6Q4P+qeKu/wAGeT/+rDpv/SHB/wBU8Vd/gzyf/wBWHTf+kOD/AKp4q7/Bnk//&#xA;AKsOm/8ASHB/1TxV3+DPJ/8A1YdN/wCkOD/qnirv8GeT/wDqw6b/ANIcH/VPFXf4M8n/APVh03/p&#xA;Dg/6p4q7/Bnk/wD6sOm/9IcH/VPFXf4M8n/9WHTf+kOD/qnirv8ABnk//qw6b/0hwf8AVPFXf4M8&#xA;n/8AVh03/pDg/wCqeKu/wZ5P/wCrDpv/AEhwf9U8Vd/gzyf/ANWHTf8ApDg/6p4q7/Bnk/8A6sOm&#xA;/wDSHB/1TxV3+DPJ/wD1YdN/6Q4P+qeKu/wZ5P8A+rDpv/SHB/1TxV3+DPJ//Vh03/pDg/6p4q7/&#xA;AAZ5P/6sOm/9IcH/AFTxV3+DPJ//AFYdN/6Q4P8Aqnirv8GeT/8Aqw6b/wBIcH/VPFXf4M8n/wDV&#xA;h03/AKQ4P+qeKpTrPlPyrFqOgJFounok+oSRyqtrCA6Cwv5OLgR7jkimh7gYqm3kz/lD9B/7Ztn/&#xA;AMmI8VYl5g83anYazd2cLsI4X4qA1BSgP8pymWEyN8RHy/U5ePLERHpifx70u/xzrH87/wDB/wDN&#xA;uD8vL+fL7P1M/Gj/ADI/b+t3+OdY/nf/AIP/AJtx/Ly/ny+z9S+NH+ZH7f1u/wAc6x/O/wDwf/Nu&#xA;P5eX8+X2fqXxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8Awf8Azbj+Xl/P&#xA;l9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W4eedYP7b/wDB/wDNmP5eX8+X2fqY&#xA;y1EB/BH7f1t/441j+d/+D/5sx/Ly/ny+z9SPzUP5kft/W7/HGsfzv/wf/NmP5eX8+X2fqX81D+ZH&#xA;7f1u/wAcax/O/wDwf/NmP5eX8+X2fqX81D+ZH7f1u/xxrH87/wDB/wDNmP5eX8+X2fqX81D+ZH7f&#xA;1u/xxrH87/8AB/8ANmP5eX8+X2fqX81D+ZH7f1u/xxrH87/8H/zZj+Xl/Pl9n6l/NQ/mR+39bv8A&#xA;HGsfzv8A8H/zZj+Xl/Pl9n6l/NQ/mR+39bX+OdY/nf8A4P8A5sx/Ly/ny+z9TIZ4n+CP2/rd/jnW&#xA;P53/AOD/AObcfy8v58vs/Unxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8A&#xA;wf8Azbj+Xl/Pl9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W7/HOsfzv/wAH/wA2&#xA;4/l5fz5fZ+pfGj/Mj9v63f451j+d/wDg/wDm3H8vL+fL7P1L40f5kft/WyryPr15rUl4t2zMIVjK&#xA;8mr9ovXsPDJ48Zh/ET72jPMSqoge5NNd/wCOp5c/7aUn/dO1LLGh3kz/AJQ/Qf8Atm2f/JiPFXmv&#xA;m6n+JNQ/4y/8ari2gmtkn2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xX1O2xX1O2xX1O2xX1O&#xA;2xX1O2xX1O2xX1O2xW5O2xW5O2xW5NH2xSCersLJ2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182n/AJ2TUP8AjL/xquLZVxSevvijh8nV98V4fJ1ffFeH&#xA;ydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV&#xA;98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFIjfRqpxZcAdU4rwB1a4UiIDO/wAr/wC+1H/Vh/XJgYZG&#xA;Ua7/AMdTy5/20pP+6dqWLW7yZ/yh+g/9s2z/AOTEeKvNfNv/ACkmof8AGX/jVcWyvSk+KK97sVr3&#xA;uxWve7Fa97sVr3uriyEHVxTwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8D&#xA;q4rwOrivA1WuFIjTO/yv/vtR/wBWH9cmBhkZRrv/AB1PLn/bSk/7p2pYtbvJn/KH6D/2zbP/AJMR&#xA;4q8183U/xJqFf9+/8ari2gmtkn2xW5dztsVuXc7bFbl3O2xW5dztsVuXc7bFbl3O2xW5dztsVuXc&#xA;7bFbl3O2xW5dzW2FIJ6uxZOxV2KuxV2KuxV2KuxV2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182/8pJqH/GX/AI1XFs2oJPv4Yo273b+GK7d7t/DFdu92&#xA;/hiu3e7fwxXbvdv4Yrt3u38MV273b+GK7d7t/DFdu91adsUgA9XVxTwebq4rwebq4rwebq4rwebq&#xA;4rwebq4rwebq4rwebq4rwebVcLIRp2KXYqzv8r/77Uf9WH9cmBryMo13/jqeXP8AtpSf907UsWt3&#xA;kz/lD9B/7Ztn/wAmI8Vea+bqf4k1D/jL/wAari2i6SfbwxX1N8j4nBwhl4mTvdyPiceEL4mTva29&#xA;8LEmR6u2xX1O2xT6nbYr6nbYr6nbYr6nbYr6nAKe9MSSkRkeoboviPx/pgs9yeE94+11F8R+ONnu&#xA;RwnvDW2FHqdtivqdtivqdtivqawsnYq7FXYqzv8AK/8AvtR/1Yf1yYGvIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFXmvm6v+JNQp/v3/jVcWwVW6T74p9Dt8V9Dt8V9Dt8V9Dt8VBiGqHCn&#xA;jDqHFeMOocV4w6hxSJAuxS7FXYq7FXYq7FXYq7FXYq7FXYq7FWd/lf8A32o/6sP65MDXkZRrv/HU&#xA;8uf9tKT/ALp2pYtbvJn/ACh+g/8AbNs/+TEeKvNfNv8Aykmob/7t/wCNVxbBy5JP9OK/B304r8Hf&#xA;Tivwd9OK/B304r8HfTivwd9OK/B304r8HfTimz3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3Oo&#xA;MV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3NHCyiSWd/lf/AH2o/wCrD+uTAwyMo13/AI6n&#xA;lz/tpSf907UsWt3kz/lD9B/7Ztn/AMmI8Vea+bf+Ul1D/jL/AMari2gXFJ6++KOHydX3xXh8nV98&#xA;V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFRHyaqcLLgDqnFeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDqn&#xA;FeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDq4pEQGd/lf8A32o/6sP65MDDIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFUn1fyKup6lcX5cj125U9Xj2A6fV38PHKpHNewFe/8AY5OOWERFmV/D&#xA;9aD/AOVbL/vw/wDI4f8AZLkeLP3R+Z/Uz49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98v&#xA;kP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q&#xA;/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9&#xA;bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u&#xA;/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/&#xA;AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1oPVvJdno1m19eSP6SsFPCUE1Y0G31YYeLP3R+Z/Uo&#xA;lgPWXyH60i9Py3/Pc/8ABD/qhjefuj8z+plWDvl8h+t3p+W/57n/AIIf9UMbz90fmf1LWDvl8h+t&#xA;3p+W/wCe5/4If9UMbz90fmf1LWDvl8h+t3p+W/57n/gh/wBUMbz90fmf1LWDvl8h+t3p+W/57n/g&#xA;h/1QxvP3R+Z/UtYO+XyH63en5b/nuf8Agh/1QxvP3R+Z/UtYO+XyH63en5b/AJ7n/gh/1QxvP3R+&#xA;Z/UtYO+XyH63en5b/nuf+CH/AFQxvP3R+Z/UtYO+XyH63en5b/nuf+CH/VDG8/dH5n9S1g75fIfr&#xA;Zj+Xq6Yst9+j2lY8YufqEHu9KUjTJwOT+ID4NGo4NuG/inmu/wDHU8uf9tKT/unalk2h3kz/AJQ/&#xA;Qf8Atm2f/JiPFUZPeSRysNggNAB9ogAln5H4QARSh+/cDKJ5SC5GPCJRXWt48spik4kEEoy70KEK&#xA;6P7g/wARTbc4splKijLhEY2Ff6xFzdKmsZVW+E0q9OIBpQ9e2XNCx722QzBmI+rlVk+FjQvTiBtv&#xA;9odMVpd9Zh5lOW4Xn0PTb/moYrStirsVdirsVdirsVdirGfzA/5RuX/jLH/xLFlDm8owtzsVdirs&#xA;VdirsVdirsVdirO/yv8A77Uf9WH9cmBryMo13/jqeXP+2lJ/3TtSxa3eTP8AlD9B/wC2bZ/8mI8V&#xA;VdQiIdmliLxHZSqPLQEq7ApGrtXkvh4bg9cTPHfcbfP7nN089tjv8B9pVbCGQsszKyIqH7f2ndzz&#xA;ZqFVIAqaVA69BQZPDA3bXqJiiPxQRLWiM0r82UylGNKfCUpQrVT4d8yHGtDtaiQysUdTcmJ3FRRS&#xA;pAqKoeyCo3GKbbNvycSLCVaRFjLhhyVW615L+zwH34ravHNO1A0LKOIPIkbkkilNt6CvTFC+N5HN&#xA;HTiOKmte5rUbgHbFVTFXYq7FXYq7FWM/mB/yjcv/ABlj/wCJYsoc3lFMWzjDqYrxh1MV4w6mK8Yd&#xA;TFeMOpivGHUxXjDqYrxh1MV4wzv8sP77Uf8AVh/XJixyMo13/jqeXP8AtpSf907UsWt3kz/lD9B/&#xA;7Ztn/wAmI8VSvVZdXGoTiDR7m4iDfDKl3JGrCg3CKaDKJ6aEjZJ+Z/W5ENXOEaAH+lH6kJ62u/8A&#xA;Viu/+k6X/mrB+Th3y/00v1svz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX89k7o/6WP6ne&#xA;trv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw75f6aX61/PZO6&#xA;P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX&#xA;89k7o/6WP6netrv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw7&#xA;5f6aX61/PZO6P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qTAeYPNIFP8PPt/xcP+&#xA;acyHFb/xD5p/6l5v+Rw/5pxVDX2pa9qVubW98ttLESGKmam46dFyOTGJiizxZZY5WEt/R8//AFKR&#xA;/wCkg5R+Tx/0v9NL9bf+fy+XyH6k00Xy/Y3/AK36T0L9H+nw9OsrPz5cuXh0oPvx/J4/6X+ml+tf&#xA;z+Xy+Q/Umn+DvLv/ACxr/wAE3/NWP5PH/S/00v1r+fy+XyH6nf4O8u/8sa/8E3/NWP5PH/S/00v1&#xA;r+fy+XyH6nf4O8u/8sa/8E3/ADVj+Tx/0v8ATS/Wv5/L5fIfqd/g7y7/AMsa/wDBN/zVj+Tx/wBL&#xA;/TS/Wv5/L5fIfqd/g7y7/wAsa/8ABN/zVj+Tx/0v9NL9a/n8vl8h+p3+DvLv/LGv/BN/zVj+Tx/0&#xA;v9NL9a/n8vl8h+p3+DvLv/LGv/BN/wA1Y/k8f9L/AE0v1r+fy+XyH6kbp2i6bpJkawgEJlAD0JNe&#xA;NadSfHLcWGOPlfxJP3tWbUTy1f3BB67/AMdTy5/20pP+6dqWWNTvJn/KH6D/ANs2z/5MR4qmDalY&#xA;JN9Xa4QTVC+nX4uR6CmKq/qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/w&#xA;Df0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xVfirsVUp7iC2j9W4dYkBpyY0&#xA;FTiqjFqen3D+nBOkr9eKHkaD2GKoj1V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq&#xA;71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq2rhuldvEEfrGKpPrv/HU8uf9tKT/&#xA;ALp2pYq7yZ/yh+g/9s2z/wCTEeKrppvKqX5Nx9RF+rgkssfrCQU47kcuXhiqa+qvg3/AN/TFXeqv&#xA;g3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/A&#xA;N/TFXeqvg3/AN/TFV+KuxVQu7a1u4TDeRLPESCUdeYqOm1DiqGtdM0iyl9ezs44JaEc44SpoeoqF&#xA;xVG+qvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXe&#xA;qvg3/AN/TFXeqvg3/AN/TFW1cN0rt4gj9YxVJ9d/46nlz/tpSf8AdO1LFXeTP+UP0H/tm2f/ACYj&#xA;xVbd3XlCK8c3v1FbxGBdpET1Aw6EsVrXFVf/ABR5e/6uEH/BjFXf4o8vf9XCD/gxirv8UeXv+rhB&#xA;/wAGMVd/ijy9/wBXCD/gxirv8UeXv+rhB/wYxVs+ZvL4AP6Rt9/8sHFWv8UeXv8Aq4Qf8GMVbPmb&#xA;y+KV1G338HB/ViqItNV0+/DNZTrchCAxiq1CeleIxVGYq7FVC7vLWxhNxeSrBECAXc0FT0xVA/4o&#xA;8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFWx5m0Agkahbmnb1F&#xA;B/4YjFWl8zaETvfQL7mWP+DnFUVaanaX6s9k63CoaMY2RgD4Gj4qiObf77b71/5qxV3Nv99t96/8&#xA;1Yq2rFuqlfnT+BOKpPrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/AOTEeKq9w/l0TuLtrIT1+MSm&#xA;LnX/ACuW+VS1OKJoyAPvbo6XNMWISI9xU/V8qfz6f98OR/N4P58fmGX5LUfzJfIu9Xyp/Pp/3w4/&#xA;m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bwfz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfI&#xA;u9Xyp/Pp/wB8OP5vB/Pj8wv5LUfzJfIu9Xyp/Pp/3w4/m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bw&#xA;fz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfIqsGoeX7YEW1zZwhvtCOSJa08eJGP5vB/&#xA;Pj8wv5LUfzJfIpll7juxVQvDZCAm/MQgqKmfjwr2+3tkZzjAWTQZQxymaiLPkl/q+VP59P8Avhyr&#xA;83g/nx+YbvyWo/mS+Rd6vlT+fT/vhx/N4P58fmF/Jaj+ZL5F3q+VP59P++HH83g/nx+YX8lqP5kv&#xA;kXer5U/n0/74cfzeD+fH5hfyWo/mS+Rd6vlT+fT/AL4cfzeD+fH5hfyWo/mS+Rd6vlT+fT/vhx/N&#xA;4P58fmF/Jaj+ZL5FWh1Dy/bArb3VnCGNSI5IlBP+xIx/N4P58fmF/Jaj+ZL5FU/TOj/8t9t/yOT/&#xA;AJqx/N4P58fmF/Jaj+ZL5F36Z0f/AJb7b/kcn/NWP5vB/Pj8wv5LUfzJfIq1ve2d2WFpcRTlKcvS&#xA;dXpXpXiTlmPNDJ9JB9zXkwZMf1RI94SzXf8AjqeXP+2lJ/3TtSybW7yZ/wAofoP/AGzbP/kxHiqh&#xA;fw+bGvJTYpp5ti37szB/Up/lUwGMT0ZCch1Q/oed/wDfel/8C+Dgj3L4ku93oed/996X/wAC+PBH&#xA;uXxJd7vQ87/770v/AIF8eCPcviS73eh53/33pf8AwL48Ee5fEl3u9Dzv/vvS/wDgXx4I9y+JLvd6&#xA;Hnf/AH3pf/AvjwR7l8SXe70PO/8AvvS/+BfHgj3L4ku93oed/wDfel/8C+PBHuXxJd7vQ87/AO+9&#xA;L/4F8eCPcviS71T/AJ37/tW/8lMkxd/zv3/at/5KYq0y+fHFGGmsPAiQ4CAUgkclnoed/wDfel/8&#xA;C+Dgj3J8SXe70PO/++9L/wCBfHgj3L4ku93oed/996X/AMC+PBHuXxJd7vQ87/770v8A4F8eCPcv&#xA;iS73eh53/wB96X/wL48Ee5fEl3u9Dzv/AL70v/gXx4I9y+JLvRFlB5r+txfpCPTvqtf3vpK3On+T&#xA;y2x4I9y+JLvT30IP99p/wIx4I9y+JLvd6EH++0/4EY8Ee5fEl3rljjT7Cha9aADCIgckGRPNJ9d/&#xA;46nlz/tpSf8AdO1LCh3kz/lD9B/7Ztn/AMmI8VX3XmnRLK4ktbm5CSxHi606HFVH/Gfl3/lrH3HF&#xA;Xf4z8u/8tY+44q7/ABn5d/5ax9xxV3+M/Lv/AC1r9xxVtvOXlwGgvFb3AP8AEDFU0tryO7gS5tla&#xA;SKUckccaEeO7Yqq82/3233r/AM1Yq7m3++2+9f8AmrFXc2/3233r/wA1YqvxV2KoTUdStNJtTeXz&#xA;mOFSFLAFt22GygnFUFp3mnRtVuPqlhK00xUtx4Muw67uFGKprzb/AH233r/zVirubf77b71/5qxV&#xA;3Nv99t96/wDNWKu5t/vtvvX/AJqxV3Nv99t96/8ANWKu5t/vtvvX/mrFXc2/3233r/zVirubf77b&#xA;71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxVNzFETUopJ7kDFXe&#xA;jD/vtfuGKu9GH/fa/cMVd6MP++1+4Yq70Yf99r9wxV3ow/77X7hiq4AAUAoB2GKt4q7FXYq7FXYq&#xA;hNR1K00m1N5fOY4VIUsAW3bYbKCcVSj/AB35Z/5aW/5FSf8ANOKu/wAd+Wf+Wlv+RUn/ADTirv8A&#xA;Hfln/lpb/kVJ/wA04q7/AB35Z/5aW/5FSf8ANOKtjz15YIJ+tkEdvSlqf+ExVr/Hfln/AJaW/wCR&#xA;Un/NOKq9l5v0LULqOzs5mknlJCJ6brWgLHdgB0GKpxzb/fbfev8AzVirubf77b71/wCasVbVi3VS&#xA;vzp/AnFUn13/AI6nlz/tpSf907UsVd5M/wCUP0H/ALZtn/yYjxVGzavp0ErQyzcXQ0YcXND9C5VL&#xA;U44miXIho8042Bss/Tulf7//AOEf/mnI/m8Xey/IZ/5v3O/Tulf7/wD+Ef8A5px/N4u9fyGf+b9z&#xA;v07pX+//APhH/wCacfzeLvX8hn/m/c79O6V/v/8A4R/+acfzeLvX8hn/AJv3O/Tulf7/AP8AhH/5&#xA;px/N4u9fyGf+b9zv07pX+/8A/hH/AOacfzeLvX8hn/m/c79O6V/v/wD4R/8AmnH83i71/IZ/5v3O&#xA;/Tulf7//AOEf/mnH83i71/IZ/wCb9zv07pX+/wD/AIR/+acfzeLvX8hn/m/cmGXuK7FVK4uYbSIz&#xA;XDcEBArQnc/6oORnOMBZZ48UskqjzQn6d0r/AH//AMI//NOVfm8Xe3/kM/8AN+536d0r/f8A/wAI&#xA;/wDzTj+bxd6/kM/837nfp3Sv9/8A/CP/AM04/m8Xev5DP/N+536d0r/f/wDwj/8ANOP5vF3r+Qz/&#xA;AM37nfp3Sv8Af/8Awj/804/m8Xev5DP/ADfud+ndK/3/AP8ACP8A804/m8Xev5DP/N+536d0r/f/&#xA;APwj/wDNOP5vF3r+Qz/zfud+ndK/3/8A8I//ADTj+bxd6/kM/wDN+536d0r/AH//AMI//NOP5vF3&#xA;r+Qz/wA37le1v7S9LC2k5lKcvhYUr/rAZPHmhk5Fqy6fJi+oJdrv/HU8uf8AbSk/7p2pZY1O8mf8&#xA;ofoP/bNs/wDkxHiqhf2HnCW8lksNUhgtmasUTRKxUU6EmJv14qh/0Z58/wCrzB/yJT/qhirv0Z58&#xA;/wCrzB/yJT/qhirv0Z58/wCrzB/yJT/qhiqvBaedYVKyX9ncEmvKWIig8B6Sx4qq+l5y/wCWjT/+&#xA;Rcv/ADViqHnsfPEzho9TtLcAU4xxVBO+/wC8SQ/jiqn+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8A&#xA;kSn/AFQxV36M8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M&#xA;8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp&#xA;/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp/wBUMVTfRrfW&#xA;reKRdau0vJGYGNo0CBVp0+FE74qmWKuxV2KpLrv/AB1PLn/bSk/7p2pYq7yZ/wAofoP/AGzbP/kx&#xA;Hiqbky12VSPdiP8AjXFXVm/lX/gj/wA0Yq6s38q/8Ef+aMVdWb+Vf+CP/NGKurN/Kv8AwR/5oxV1&#xA;Zv5V/wCCP/NGKurN/Kv/AAR/5oxV1Zv5V/4I/wDNGKurN/Kv/BH/AJoxV1Zv5V/4I/8ANGKr8Vdi&#xA;qnOvKMjjz9q0xViF3pVw91O48tPMGkciUamU51Y/Fw5/DXrTFU+0XSLSxjW6jtGs7mZAJYmnefjv&#xA;XjyZ2X6Riqa4qh76S7htZJbKEXM6iqQlgnPfpybYYqkv6W83f9WBf+kuLFXfpbzd/wBWBf8ApLix&#xA;VN9Nmv7i2Euo2ws5iSPRDiSgHQ81NN8VReKuxV2KpLrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/&#xA;AOTEeKpVquna/NqM8lrpOn3ELNVJZq+owoN2/fL+rKJ6TDM2YglyIa3PCNCRAQn6K8zf9WPS/uP/&#xA;AFXyP5HT/wAwMv5R1P8APKrb6Zrikm68v6fKP2RG/pmviSzyfqx/I6f+YF/lHU/zyr/o+/8A+pZs&#xA;/wDpIX/mjH8jp/5gX+UdT/PLv0ff/wDUs2f/AEkL/wA0Y/kdP/MC/wAo6n+eXfo+/wD+pZs/+khf&#xA;+aMfyOn/AJgX+UdT/PKaWGiWM1uHv9Kt7WepBjUiQAdjyAGP5HT/AMwL/KOp/nlE/wCH9E/5YYf+&#xA;BGP5HT/zAv8AKOp/nl3+H9E/5YYf+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf5&#xA;5d/h/RP+WGH/AIEY/kdP/MC/yjqf55d/h/RP+WGH/gRj+R0/8wL/ACjqf55d/h/RP+WGH/gRj+R0&#xA;/wDMC/yjqf55d/h/RP8Alhh/4EY/kdP/ADAv8o6n+eXf4f0T/lhh/wCBGP5HT/zAv8o6n+eXf4f0&#xA;T/lhh/4EY/kdP/MC/wAo6n+eXf4f0T/lhh/4EY/kdP8AzAv8o6n+eXf4f0T/AJYYf+BGP5HT/wAw&#xA;L/KOp/nl3+H9E/5YYf8AgRj+R0/8wL/KOp/nl3+H9E/5YYf+BGP5HT/zAv8AKOp/nl3+H9E/5YYf&#xA;+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf55RFpp1jYljZwJAZKcuApWnSv35bi&#xA;wY8X0imrNqcuauKVpdrv/HU8uf8AbSk/7p2pZY1O8mf8ofoP/bNs/wDkxHiqzW4ZJLdhHDeSn1lN&#xA;LOQRPSku/Iharv4ntiqR/Urn/li1v/pLX/mrFXfUrn/li1v/AKS1/wCasVTjStCR1hvpZdRt5EcP&#xA;9XuLkt9htg4FQQaYqyHFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FUl13/jqeXP+&#xA;2lJ/3TtSxV3kz/lD9B/7Ztn/AMmI8VXa5ZCW1AS3uLotKrFLaVYXFBJ8RaqVHxdK4qk0OjLIzCWw&#xA;1GABSwZ7wsCR0Uem7mp99sVU/wBFP/1adT/6TV/6rYqitPiudNnNxBpGoM5UpSW6jkWhoejSnwxV&#xA;NE1fVGdVbRrhFYgFjJDQA99pMVTfFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYqkuu/&#xA;8dTy5/20pP8AunalirvJn/KH6D/2zbP/AJMR4qq+YLQ3lkkQs3v6ShvSimEBFFccuZZa9aUxVJ7D&#xA;SWgkkY6NPa8o3Xk92Jw1R9gKDLQn+ag+eKoX9Bt/1L1z/wBxFf8Aqtirv0G3/UvXP/cRX/qtiqYa&#xA;R5ftjcCe50yewe3ZJIi92ZgzA1+ykjdKd8VZPirsVdirsVdirsVdiqHvb620+A3N3IIogQCzEAVP&#xA;TriqXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVd/i3QP+WyP/AIJf+asVd/i3QP8Alsj/AOCX&#xA;/mrFXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVbXzXoLMFW7jJJoByXqf9liqa82/3233r/zV&#xA;irubf77b71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxV3mC2GoW&#xA;ggm09b9Y5lZY3na3HSRefMAV+Xv7Yqg9F0HSoBJPJp6abOwaLit0bjlGwFd2NBv7VxVU/wAG+Uf+&#xA;WVf+R8v/AFVxVcPJPlVhVbIEeImmP/M3FW/8D+V/+WH/AJKzf9VcVTexsbXTbVLKyT0oIq8EqWpy&#xA;Jc7uSepxVEYq7FXYq7FXYq7FVrxxyrwkUOvgwBH44qpfUrP/AJZ4v+AX+mKu+pWf/LPF/wAAv9MV&#xA;d9Ss/wDlni/4Bf6Yq76lZ/8ALPF/wC/0xV31Kz/5Z4v+AX+mKu+pWf8Ayzxf8Av9MVd9TsxuII/+&#xA;AX+mKq+KuxV2KpLrv/HU8uf9tKT/ALp2pYq7yZ/yh+g/9s2z/wCTEeKo280fT9QQxXsInjLiTi2w&#xA;DDnQ/DQ/tnFUF/g/y1/ywR/e/wDzVirv8H+Wv+WCP73/AOasVTOzsrXT7dbWzjEMKVKoK0FTU9a9&#xA;ziqvirsVSjzLa3l5pvo2FfW9RSCpINBWu4zG1uPJkxEQ5uZ2dlx4s1z5MNPlzzcSSJ5AOw5HKI6e&#xA;QAuJ/wBOXKnqYGRrIK/qBr/Dfm//AH/J/wAEcP5c/wA0/wCnLH8xH/VB/wAqwq23l7zTHKrTSSOo&#xA;YEjk3QHfKsulzEjhBG+/qJbsOrwRB45CXd6AHoaAhFB60GbR0q7FUt163ubnTZIbSvrN9niaH8Mp&#xA;1MJTxER5uRo8kIZomXJhL+XPNjGqTSKPDkxzBwaXLGFTBJ/rl2WfV4ZyuEhEd3ACt/w35v8A9/yf&#xA;8Ect/Ln+af8ATlp/MR/1Qf8AKsL4/LvmtQeckj+HxsMx9To9ROuC4/5xcnTa3TQB4yJf5oD0G1Vk&#xA;tYUcUZY1DA+IArm2HJ0kyDIq2Fi7FXYq7FXYq7FUl13/AI6nlz/tpSf907UsVSnyn5s8q23lXRbe&#xA;41rT4ZodPtY5I5LqFXR1hjVlZWkBBBG4xVNv8Z+T/wDq/ab/ANJkH/VTFXf4z8n/APV+03/pMg/6&#xA;qYq7/Gfk/wD6v2m/9JkH/VTFXf4z8n/9X7Tf+kyD/qpirv8AGfk//q/ab/0mQf8AVTFXf4z8n/8A&#xA;V+03/pMg/wCqmKu/xn5P/wCr9pv/AEmQf9VMVd/jPyf/ANX7Tf8ApMg/6qYq7/Gfk/8A6v2m/wDS&#xA;ZB/1UxV3+M/J/wD1ftN/6TIP+qmKu/xn5P8A+r9pv/SZB/1UxV3+M/J//V+03/pMg/6qYq7/ABn5&#xA;P/6v2m/9JkH/AFUxV3+M/J//AFftN/6TIP8Aqpirv8Z+T/8Aq/ab/wBJkH/VTFXf4z8n/wDV+03/&#xA;AKTIP+qmKu/xn5P/AOr9pv8A0mQf9VMVd/jPyf8A9X7Tf+kyD/qpirv8Z+T/APq/ab/0mQf9VMVd&#xA;/jPyf/1ftN/6TIP+qmKu/wAZ+T/+r9pv/SZB/wBVMVd/jPyf/wBX7Tf+kyD/AKqYq7/Gfk//AKv2&#xA;m/8ASZB/1UxVKdZ82eVZdR0B4ta090g1CSSVluoSEQ2F/HyciTYcnUVPcjFX/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Example of an Interactive PDF Form</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">PDF forms</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:creator>
+            <rdf:Bag/>
+         </dc:creator>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>forms</rdf:li>
+               <rdf:li>flat</rdf:li>
+               <rdf:li>fillable</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+         <pdf:Producer>Adobe PDF Library 8.0</pdf:Producer>
+         <pdf:Trapped>False</pdf:Trapped>
+         <pdf:Keywords>forms, flat, fillable</pdf:Keywords>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj18 0 obj<</CreationDate(D:20090414174258-07'00')/Creator(Adobe InDesign CS3 \(5.0.4\))/Keywords(forms, flat, fillable)/ModDate(D:20150624101233+02'00')/Producer(Adobe PDF Library 8.0)/Subject(PDF forms)/Title(Example of an Interactive PDF Form)/Trapped/False>>endobj20 0 obj<</AcroForm 95 0 R/Extensions<</ADBE<</BaseVersion/1.7/ExtensionLevel 3>>>>/MarkInfo<</Marked false>>/Metadata 3 0 R/Names 96 0 R/OpenAction 21 0 R/Outlines 196 0 R/Pages 16 0 R/Type/Catalog/ViewerPreferences<</Direction/L2R>>>>endobj122 0 obj<</AA<<>>/AP<</N 197 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[491.28 602.19 578.88 620.91]/Subtype/Widget/T(ZIP)/TU(ZIP)/Type/Annot>>endobj196 0 obj<</Count 0/Type/Outlines>>endobj197 0 obj<</BBox[0.0 0.0 87.6 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobjxref0 10000000000 65535 f
+3 10000080313 00000 n
+18 10000102006 00000 n
+20 10000102275 00000 n
+122 10000102520 00000 n
+196 20000102745 00000 n
+0000102789 00000 n
+trailer<</Size 198/Root 20 0 R/Info 18 0 R/ID[<6F185C876244254CBA5693F8CDC7D0AA><325E0E181BDC473D94BF4D6DD2CA5B68>]/Prev 76241>>startxref102974%%EOF

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -197,6 +197,11 @@ var PSPDFKitPlugin = new function() {
         getAllUnsavedAnnotations: ['callback']
     });
     
+    //Forms
+    addMethods({
+        setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
+        getFormFieldValue: ['fullyQualifiedName', 'callback'],
+    });
 };
 module.exports = PSPDFKitPlugin;
 

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -191,7 +191,7 @@ var PSPDFKitPlugin = new function() {
     
     // Instant JSON
     addMethods({
-        addAnnotations: ['jsonAnnotations', 'callback'],
+        applyInstantJSON: ['jsonValue', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
         removeAnnotation: ['jsonAnnotation', 'callback'],
         getAnnotations: ['pageIndex', 'type', 'callback'],

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -192,7 +192,7 @@ var PSPDFKitPlugin = new function() {
     addMethods({
         addAnnotations: ['jsonAnnotations', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
-        removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+        removeAnnotation: ['jsonAnnotation', 'callback'],
         getAnnotations: ['pageIndex', 'type', 'callback'],
         getAllUnsavedAnnotations: ['callback']
     });

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -3,7 +3,7 @@ cordova.define("pspdfkit-cordova-ios.PSPDFKitPlugin", function(require, exports,
 //  PSPDFKit.h
 //  PSPDFPlugin for Apache Cordova
 //
-//  Copyright © 2013-2017 PSPDFKit GmbH. All rights reserved.
+//  Copyright © 2013-2018 PSPDFKit GmbH. All rights reserved.
 //
 //  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY AUSTRIAN COPYRIGHT LAW
 //  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
@@ -106,6 +106,7 @@ var PSPDFKitPlugin = new function() {
         reload: [],
         search: ['query', 'animated', 'headless'],
         saveAnnotations: ['callback'],
+        getHasDirtyAnnotations: ['callback'],
     });
     
     //configuration
@@ -179,13 +180,23 @@ var PSPDFKitPlugin = new function() {
     {
         callback(rightBarButtonItems);
     }
-	
-	//annotation toolbar
-	addMethods({
-		hideAnnotationToolbar: [],
-		showAnnotationToolbar: [],
-		toggleAnnotationToolbar: [],
-	});
+
+    //annotation toolbar
+    addMethods({
+        hideAnnotationToolbar: [],
+        showAnnotationToolbar: [],
+        toggleAnnotationToolbar: [],
+    });
+    
+    //Instant JSON
+    addMethods({
+        addAnnotations: ['jsonAnnotations', 'callback'],
+        addAnnotation: ['jsonAnnotation', 'callback'],
+        removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+        getAnnotations: ['pageIndex', 'type', 'callback'],
+        getAllUnsavedAnnotations: ['callback']
+    });
+    
 };
 module.exports = PSPDFKitPlugin;
 

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -101,7 +101,8 @@ var PSPDFKitPlugin = new function() {
     // Document methods
     
     addMethods({
-        present: ['path', 'callback', 'options', 'xfdfPath'],
+        present: ['path', 'callback', 'options'],
+        presentWithXFDF: ['path', 'xfdfPath', 'callback', 'options'],
         dismiss: ['callback'],
         reload: [],
         search: ['query', 'animated', 'headless'],

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -101,7 +101,7 @@ var PSPDFKitPlugin = new function() {
     //document methods
     
     addMethods({
-        present: ['path', 'callback', 'options'],
+        present: ['path', 'callback', 'options', 'xfdfPath'],
         dismiss: ['callback'],
         reload: [],
         search: ['query', 'animated', 'headless'],

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -3,7 +3,7 @@ cordova.define("pspdfkit-cordova-ios.PSPDFKitPlugin", function(require, exports,
 //  PSPDFKit.h
 //  PSPDFPlugin for Apache Cordova
 //
-//  Copyright © 2013-2018 PSPDFKit GmbH. All rights reserved.
+//  Copyright © 2013-2019 PSPDFKit GmbH. All rights reserved.
 //
 //  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY AUSTRIAN COPYRIGHT LAW
 //  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
@@ -13,7 +13,7 @@ cordova.define("pspdfkit-cordova-ios.PSPDFKitPlugin", function(require, exports,
 
 var PSPDFKitPlugin = new function() {
     
-    //utilities
+    // Utilities
     
     var self = this;
     function addMethods(methods) {
@@ -42,7 +42,7 @@ var PSPDFKitPlugin = new function() {
         }
     }
     
-    //events
+    // Events
     
     var listeners = {};
     
@@ -86,19 +86,19 @@ var PSPDFKitPlugin = new function() {
         }
     }
 
-    //license key
+    // License key
     
     addMethods({
         setLicenseKey: ['key'],
     });
 
-    //PDF Generation method
+    // PDF Generation method
     
     addMethods({
         convertPDFFromHTMLString: ['html', 'fileName', 'options', 'callback'],
     });
     
-    //document methods
+    // Document methods
     
     addMethods({
         present: ['path', 'callback', 'options', 'xfdfPath'],
@@ -109,7 +109,7 @@ var PSPDFKitPlugin = new function() {
         getHasDirtyAnnotations: ['callback'],
     });
     
-    //configuration
+    // Configuration
     
     addMethods({
         setOptions: ['options', 'animated'],
@@ -118,7 +118,7 @@ var PSPDFKitPlugin = new function() {
         getOption: ['name', 'callback'],
     });
     
-    //page scrolling
+    // Page scrolling
     
     addMethods({
         setPage: ['page', 'animated'],
@@ -129,20 +129,20 @@ var PSPDFKitPlugin = new function() {
         scrollToPreviousPage: ['animated'],
     });
 
-    //appearance
+    // Appearance
     
     addMethods({
         setAppearanceMode: ['appearanceMode'],
     });
 
-    //cache
+    // Cache
 
     addMethods({
         clearCache: [],
         removeCacheForPresentedDocument: [],
     });
 
-    //toolbar
+    // Toolbar
     
     var leftBarButtonItems = ['close'];
     var rightBarButtonItems = ['search', 'outline', 'thumbnails'];
@@ -181,14 +181,14 @@ var PSPDFKitPlugin = new function() {
         callback(rightBarButtonItems);
     }
 
-    //annotation toolbar
+    // Annotation toolbar
     addMethods({
         hideAnnotationToolbar: [],
         showAnnotationToolbar: [],
         toggleAnnotationToolbar: [],
     });
     
-    //Instant JSON
+    // Instant JSON
     addMethods({
         addAnnotations: ['jsonAnnotations', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
@@ -197,7 +197,7 @@ var PSPDFKitPlugin = new function() {
         getAllUnsavedAnnotations: ['callback']
     });
     
-    //Forms
+    // Forms
     addMethods({
         setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
         getFormFieldValue: ['fullyQualifiedName', 'callback'],

--- a/CordovaDemo/www/pdf/Form_example.pdf
+++ b/CordovaDemo/www/pdf/Form_example.pdf
@@ -1,0 +1,643 @@
+%PDF-1.7%‚„œ”
+20 0 obj<</AcroForm 95 0 R/Extensions<</ADBE<</BaseVersion/1.7/ExtensionLevel 3>>>>/MarkInfo<</Marked false>>/Metadata 3 0 R/Names 96 0 R/OpenAction 21 0 R/Pages 16 0 R/Type/Catalog/ViewerPreferences<</Direction/L2R>>>>endobj95 0 obj<</DA(/Helv 0 Tf 0 g )/DR<</Encoding<</PDFDocEncoding 10 0 R>>/Font<</HeBo 8 0 R/Helv 9 0 R/ZaDb 115 0 R>>>>/Fields[108 0 R 109 0 R 110 0 R 111 0 R 112 0 R 113 0 R 116 0 R 117 0 R 121 0 R 122 0 R 129 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 106 0 R 107 0 R 114 0 R 118 0 R 119 0 R 120 0 R 123 0 R 124 0 R 125 0 R 7 0 R 128 0 R]/SigFlags 1>>endobj3 0 obj<</Length 21616/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.4-c005 78.147326, 2012/08/23-13:03:03        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stMfs="http://ns.adobe.com/xap/1.0/sType/ManifestItem#"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmpMM:InstanceID>uuid:24e746ca-8e98-a941-bee6-936d98995948</xmpMM:InstanceID>
+         <xmpMM:DocumentID>adobe:docid:indd:5235ff14-294b-11de-919f-d8c16f47bc75</xmpMM:DocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>5235ff13-294b-11de-919f-d8c16f47bc75</stRef:instanceID>
+            <stRef:documentID>adobe:docid:indd:87ea89f9-0d9e-11db-8dd1-d4ba47cf2fcb</stRef:documentID>
+         </xmpMM:DerivedFrom>
+         <xmpMM:Manifest>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stMfs:linkForm>ReferenceStream</stMfs:linkForm>
+                  <xmpMM:placedXResolution>72.00</xmpMM:placedXResolution>
+                  <xmpMM:placedYResolution>72.00</xmpMM:placedYResolution>
+                  <xmpMM:placedResolutionUnit>Inches</xmpMM:placedResolutionUnit>
+                  <stMfs:reference rdf:parseType="Resource">
+                     <stRef:instanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</stRef:instanceID>
+                     <stRef:documentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</stRef:documentID>
+                  </stMfs:reference>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpMM:Manifest>
+         <xmp:CreateDate>2009-04-14T17:42:58-07:00</xmp:CreateDate>
+         <xmp:ModifyDate>2014-03-06T17:57:29+01:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2014-03-06T17:57:29+01:00</xmp:MetadataDate>
+         <xmp:CreatorTool>Adobe InDesign CS3 (5.0.4)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4AE0Fkb2JlAGQAAAAAAQUAAilI/9sAhAAKBwcHBwcKBwcKDgkJCQ4RDAsLDBEU&#xA;EBAQEBAUEQ8RERERDxERFxoaGhcRHyEhISEfKy0tLSsyMjIyMjIyMjIyAQsJCQ4MDh8XFx8rIh0i&#xA;KzIrKysrMjIyMjIyMjIyMjIyMjIyMjI+Pj4+PjJAQEBAQEBAQEBAQEBAQEBAQEBAQED/wAARCAEA&#xA;AMYDAREAAhEBAxEB/8QBogAAAAcBAQEBAQAAAAAAAAAABAUDAgYBAAcICQoLAQACAgMBAQEBAQAA&#xA;AAAAAAABAAIDBAUGBwgJCgsQAAIBAwMCBAIGBwMEAgYCcwECAxEEAAUhEjFBUQYTYSJxgRQykaEH&#xA;FbFCI8FS0eEzFmLwJHKC8SVDNFOSorJjc8I1RCeTo7M2F1RkdMPS4ggmgwkKGBmElEVGpLRW01Uo&#xA;GvLj88TU5PRldYWVpbXF1eX1ZnaGlqa2xtbm9jdHV2d3h5ent8fX5/c4SFhoeIiYqLjI2Oj4KTlJ&#xA;WWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+hEAAgIBAgMFBQQFBgQIAwNtAQACEQMEIRIxQQVRE2Ei&#xA;BnGBkTKhsfAUwdHhI0IVUmJy8TMkNEOCFpJTJaJjssIHc9I14kSDF1STCAkKGBkmNkUaJ2R0VTfy&#xA;o7PDKCnT4/OElKS0xNTk9GV1hZWltcXV5fVGVmZ2hpamtsbW5vZHV2d3h5ent8fX5/c4SFhoeIiY&#xA;qLjI2Oj4OUlZaXmJmam5ydnp+So6SlpqeoqaqrrK2ur6/9oADAMBAAIRAxEAPwCbeU/KflW58q6L&#xA;cXGi6fNNNp9rJJJJaws7u0MbMzM0ZJJJ3OKpt/gzyf8A9WHTf+kOD/qnirv8GeT/APqw6b/0hwf9&#xA;U8Vd/gzyf/1YdN/6Q4P+qeKu/wAGeT/+rDpv/SHB/wBU8Vd/gzyf/wBWHTf+kOD/AKp4q7/Bnk//&#xA;AKsOm/8ASHB/1TxV3+DPJ/8A1YdN/wCkOD/qnirv8GeT/wDqw6b/ANIcH/VPFXf4M8n/APVh03/p&#xA;Dg/6p4q7/Bnk/wD6sOm/9IcH/VPFXf4M8n/9WHTf+kOD/qnirv8ABnk//qw6b/0hwf8AVPFXf4M8&#xA;n/8AVh03/pDg/wCqeKu/wZ5P/wCrDpv/AEhwf9U8Vd/gzyf/ANWHTf8ApDg/6p4q7/Bnk/8A6sOm&#xA;/wDSHB/1TxV3+DPJ/wD1YdN/6Q4P+qeKu/wZ5P8A+rDpv/SHB/1TxV3+DPJ//Vh03/pDg/6p4q7/&#xA;AAZ5P/6sOm/9IcH/AFTxV3+DPJ//AFYdN/6Q4P8Aqnirv8GeT/8Aqw6b/wBIcH/VPFXf4M8n/wDV&#xA;h03/AKQ4P+qeKpTrPlPyrFqOgJFounok+oSRyqtrCA6Cwv5OLgR7jkimh7gYqm3kz/lD9B/7Ztn/&#xA;AMmI8VYl5g83anYazd2cLsI4X4qA1BSgP8pymWEyN8RHy/U5ePLERHpifx70u/xzrH87/wDB/wDN&#xA;uD8vL+fL7P1M/Gj/ADI/b+t3+OdY/nf/AIP/AJtx/Ly/ny+z9S+NH+ZH7f1u/wAc6x/O/wDwf/Nu&#xA;P5eX8+X2fqXxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8Awf8Azbj+Xl/P&#xA;l9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W4eedYP7b/wDB/wDNmP5eX8+X2fqY&#xA;y1EB/BH7f1t/441j+d/+D/5sx/Ly/ny+z9SPzUP5kft/W7/HGsfzv/wf/NmP5eX8+X2fqX81D+ZH&#xA;7f1u/wAcax/O/wDwf/NmP5eX8+X2fqX81D+ZH7f1u/xxrH87/wDB/wDNmP5eX8+X2fqX81D+ZH7f&#xA;1u/xxrH87/8AB/8ANmP5eX8+X2fqX81D+ZH7f1u/xxrH87/8H/zZj+Xl/Pl9n6l/NQ/mR+39bv8A&#xA;HGsfzv8A8H/zZj+Xl/Pl9n6l/NQ/mR+39bX+OdY/nf8A4P8A5sx/Ly/ny+z9TIZ4n+CP2/rd/jnW&#xA;P53/AOD/AObcfy8v58vs/Unxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8A&#xA;wf8Azbj+Xl/Pl9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W7/HOsfzv/wAH/wA2&#xA;4/l5fz5fZ+pfGj/Mj9v63f451j+d/wDg/wDm3H8vL+fL7P1L40f5kft/WyryPr15rUl4t2zMIVjK&#xA;8mr9ovXsPDJ48Zh/ET72jPMSqoge5NNd/wCOp5c/7aUn/dO1LLGh3kz/AJQ/Qf8Atm2f/JiPFXmv&#xA;m6n+JNQ/4y/8ari2gmtkn2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xX1O2xX1O2xX1O2xX1O&#xA;2xX1O2xX1O2xX1O2xW5O2xW5O2xW5NH2xSCersLJ2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182n/AJ2TUP8AjL/xquLZVxSevvijh8nV98V4fJ1ffFeH&#xA;ydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV&#xA;98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFIjfRqpxZcAdU4rwB1a4UiIDO/wAr/wC+1H/Vh/XJgYZG&#xA;Ua7/AMdTy5/20pP+6dqWLW7yZ/yh+g/9s2z/AOTEeKvNfNv/ACkmof8AGX/jVcWyvSk+KK97sVr3&#xA;uxWve7Fa97sVr3uriyEHVxTwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8D&#xA;q4rwOrivA1WuFIjTO/yv/vtR/wBWH9cmBhkZRrv/AB1PLn/bSk/7p2pYtbvJn/KH6D/2zbP/AJMR&#xA;4q8183U/xJqFf9+/8ari2gmtkn2xW5dztsVuXc7bFbl3O2xW5dztsVuXc7bFbl3O2xW5dztsVuXc&#xA;7bFbl3O2xW5dzW2FIJ6uxZOxV2KuxV2KuxV2KuxV2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182/8pJqH/GX/AI1XFs2oJPv4Yo273b+GK7d7t/DFdu92&#xA;/hiu3e7fwxXbvdv4Yrt3u38MV273b+GK7d7t/DFdu91adsUgA9XVxTwebq4rwebq4rwebq4rwebq&#xA;4rwebq4rwebq4rwebq4rwebVcLIRp2KXYqzv8r/77Uf9WH9cmBryMo13/jqeXP8AtpSf907UsWt3&#xA;kz/lD9B/7Ztn/wAmI8Vea+bqf4k1D/jL/wAari2i6SfbwxX1N8j4nBwhl4mTvdyPiceEL4mTva29&#xA;8LEmR6u2xX1O2xT6nbYr6nbYr6nbYr6nbYr6nAKe9MSSkRkeoboviPx/pgs9yeE94+11F8R+ONnu&#xA;RwnvDW2FHqdtivqdtivqdtivqawsnYq7FXYqzv8AK/8AvtR/1Yf1yYGvIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFXmvm6v+JNQp/v3/jVcWwVW6T74p9Dt8V9Dt8V9Dt8V9Dt8VBiGqHCn&#xA;jDqHFeMOocV4w6hxSJAuxS7FXYq7FXYq7FXYq7FXYq7FXYq7FWd/lf8A32o/6sP65MDXkZRrv/HU&#xA;8uf9tKT/ALp2pYtbvJn/ACh+g/8AbNs/+TEeKvNfNv8Aykmob/7t/wCNVxbBy5JP9OK/B304r8Hf&#xA;Tivwd9OK/B304r8HfTivwd9OK/B304r8HfTimz3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3Oo&#xA;MV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3NHCyiSWd/lf/AH2o/wCrD+uTAwyMo13/AI6n&#xA;lz/tpSf907UsWt3kz/lD9B/7Ztn/AMmI8Vea+bf+Ul1D/jL/AMari2gXFJ6++KOHydX3xXh8nV98&#xA;V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFRHyaqcLLgDqnFeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDqn&#xA;FeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDq4pEQGd/lf8A32o/6sP65MDDIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFUn1fyKup6lcX5cj125U9Xj2A6fV38PHKpHNewFe/8AY5OOWERFmV/D&#xA;9aD/AOVbL/vw/wDI4f8AZLkeLP3R+Z/Uz49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98v&#xA;kP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q&#xA;/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9&#xA;bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u&#xA;/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/&#xA;AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1oPVvJdno1m19eSP6SsFPCUE1Y0G31YYeLP3R+Z/Uo&#xA;lgPWXyH60i9Py3/Pc/8ABD/qhjefuj8z+plWDvl8h+t3p+W/57n/AIIf9UMbz90fmf1LWDvl8h+t&#xA;3p+W/wCe5/4If9UMbz90fmf1LWDvl8h+t3p+W/57n/gh/wBUMbz90fmf1LWDvl8h+t3p+W/57n/g&#xA;h/1QxvP3R+Z/UtYO+XyH63en5b/nuf8Agh/1QxvP3R+Z/UtYO+XyH63en5b/AJ7n/gh/1QxvP3R+&#xA;Z/UtYO+XyH63en5b/nuf+CH/AFQxvP3R+Z/UtYO+XyH63en5b/nuf+CH/VDG8/dH5n9S1g75fIfr&#xA;Zj+Xq6Yst9+j2lY8YufqEHu9KUjTJwOT+ID4NGo4NuG/inmu/wDHU8uf9tKT/unalk2h3kz/AJQ/&#xA;Qf8Atm2f/JiPFUZPeSRysNggNAB9ogAln5H4QARSh+/cDKJ5SC5GPCJRXWt48spik4kEEoy70KEK&#xA;6P7g/wARTbc4splKijLhEY2Ff6xFzdKmsZVW+E0q9OIBpQ9e2XNCx722QzBmI+rlVk+FjQvTiBtv&#xA;9odMVpd9Zh5lOW4Xn0PTb/moYrStirsVdirsVdirsVdirGfzA/5RuX/jLH/xLFlDm8owtzsVdirs&#xA;VdirsVdirsVdirO/yv8A77Uf9WH9cmBryMo13/jqeXP+2lJ/3TtSxa3eTP8AlD9B/wC2bZ/8mI8V&#xA;VdQiIdmliLxHZSqPLQEq7ApGrtXkvh4bg9cTPHfcbfP7nN089tjv8B9pVbCGQsszKyIqH7f2ndzz&#xA;ZqFVIAqaVA69BQZPDA3bXqJiiPxQRLWiM0r82UylGNKfCUpQrVT4d8yHGtDtaiQysUdTcmJ3FRRS&#xA;pAqKoeyCo3GKbbNvycSLCVaRFjLhhyVW615L+zwH34ravHNO1A0LKOIPIkbkkilNt6CvTFC+N5HN&#xA;HTiOKmte5rUbgHbFVTFXYq7FXYq7FWM/mB/yjcv/ABlj/wCJYsoc3lFMWzjDqYrxh1MV4w6mK8Yd&#xA;TFeMOpivGHUxXjDqYrxh1MV4wzv8sP77Uf8AVh/XJixyMo13/jqeXP8AtpSf907UsWt3kz/lD9B/&#xA;7Ztn/wAmI8VSvVZdXGoTiDR7m4iDfDKl3JGrCg3CKaDKJ6aEjZJ+Z/W5ENXOEaAH+lH6kJ62u/8A&#xA;Viu/+k6X/mrB+Th3y/00v1svz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX89k7o/6WP6ne&#xA;trv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw75f6aX61/PZO6&#xA;P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX&#xA;89k7o/6WP6netrv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw7&#xA;5f6aX61/PZO6P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qTAeYPNIFP8PPt/xcP+&#xA;acyHFb/xD5p/6l5v+Rw/5pxVDX2pa9qVubW98ttLESGKmam46dFyOTGJiizxZZY5WEt/R8//AFKR&#xA;/wCkg5R+Tx/0v9NL9bf+fy+XyH6k00Xy/Y3/AK36T0L9H+nw9OsrPz5cuXh0oPvx/J4/6X+ml+tf&#xA;z+Xy+Q/Umn+DvLv/ACxr/wAE3/NWP5PH/S/00v1r+fy+XyH6nf4O8u/8sa/8E3/NWP5PH/S/00v1&#xA;r+fy+XyH6nf4O8u/8sa/8E3/ADVj+Tx/0v8ATS/Wv5/L5fIfqd/g7y7/AMsa/wDBN/zVj+Tx/wBL&#xA;/TS/Wv5/L5fIfqd/g7y7/wAsa/8ABN/zVj+Tx/0v9NL9a/n8vl8h+p3+DvLv/LGv/BN/zVj+Tx/0&#xA;v9NL9a/n8vl8h+p3+DvLv/LGv/BN/wA1Y/k8f9L/AE0v1r+fy+XyH6kbp2i6bpJkawgEJlAD0JNe&#xA;NadSfHLcWGOPlfxJP3tWbUTy1f3BB67/AMdTy5/20pP+6dqWWNTvJn/KH6D/ANs2z/5MR4qmDalY&#xA;JN9Xa4QTVC+nX4uR6CmKq/qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/w&#xA;Df0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xVfirsVUp7iC2j9W4dYkBpyY0&#xA;FTiqjFqen3D+nBOkr9eKHkaD2GKoj1V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq&#xA;71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq2rhuldvEEfrGKpPrv/HU8uf9tKT/&#xA;ALp2pYq7yZ/yh+g/9s2z/wCTEeKrppvKqX5Nx9RF+rgkssfrCQU47kcuXhiqa+qvg3/AN/TFXeqv&#xA;g3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/A&#xA;N/TFXeqvg3/AN/TFV+KuxVQu7a1u4TDeRLPESCUdeYqOm1DiqGtdM0iyl9ezs44JaEc44SpoeoqF&#xA;xVG+qvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXe&#xA;qvg3/AN/TFXeqvg3/AN/TFW1cN0rt4gj9YxVJ9d/46nlz/tpSf8AdO1LFXeTP+UP0H/tm2f/ACYj&#xA;xVbd3XlCK8c3v1FbxGBdpET1Aw6EsVrXFVf/ABR5e/6uEH/BjFXf4o8vf9XCD/gxirv8UeXv+rhB&#xA;/wAGMVd/ijy9/wBXCD/gxirv8UeXv+rhB/wYxVs+ZvL4AP6Rt9/8sHFWv8UeXv8Aq4Qf8GMVbPmb&#xA;y+KV1G338HB/ViqItNV0+/DNZTrchCAxiq1CeleIxVGYq7FVC7vLWxhNxeSrBECAXc0FT0xVA/4o&#xA;8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFWx5m0Agkahbmnb1F&#xA;B/4YjFWl8zaETvfQL7mWP+DnFUVaanaX6s9k63CoaMY2RgD4Gj4qiObf77b71/5qxV3Nv99t96/8&#xA;1Yq2rFuqlfnT+BOKpPrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/AOTEeKq9w/l0TuLtrIT1+MSm&#xA;LnX/ACuW+VS1OKJoyAPvbo6XNMWISI9xU/V8qfz6f98OR/N4P58fmGX5LUfzJfIu9Xyp/Pp/3w4/&#xA;m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bwfz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfI&#xA;u9Xyp/Pp/wB8OP5vB/Pj8wv5LUfzJfIu9Xyp/Pp/3w4/m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bw&#xA;fz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfIqsGoeX7YEW1zZwhvtCOSJa08eJGP5vB/&#xA;Pj8wv5LUfzJfIpll7juxVQvDZCAm/MQgqKmfjwr2+3tkZzjAWTQZQxymaiLPkl/q+VP59P8Avhyr&#xA;83g/nx+YbvyWo/mS+Rd6vlT+fT/vhx/N4P58fmF/Jaj+ZL5F3q+VP59P++HH83g/nx+YX8lqP5kv&#xA;kXer5U/n0/74cfzeD+fH5hfyWo/mS+Rd6vlT+fT/AL4cfzeD+fH5hfyWo/mS+Rd6vlT+fT/vhx/N&#xA;4P58fmF/Jaj+ZL5FWh1Dy/bArb3VnCGNSI5IlBP+xIx/N4P58fmF/Jaj+ZL5FU/TOj/8t9t/yOT/&#xA;AJqx/N4P58fmF/Jaj+ZL5F36Z0f/AJb7b/kcn/NWP5vB/Pj8wv5LUfzJfIq1ve2d2WFpcRTlKcvS&#xA;dXpXpXiTlmPNDJ9JB9zXkwZMf1RI94SzXf8AjqeXP+2lJ/3TtSybW7yZ/wAofoP/AGzbP/kxHiqh&#xA;fw+bGvJTYpp5ti37szB/Up/lUwGMT0ZCch1Q/oed/wDfel/8C+Dgj3L4ku93oed/996X/wAC+PBH&#xA;uXxJd7vQ87/770v/AIF8eCPcviS73eh53/33pf8AwL48Ee5fEl3u9Dzv/vvS/wDgXx4I9y+JLvd6&#xA;Hnf/AH3pf/AvjwR7l8SXe70PO/8AvvS/+BfHgj3L4ku93oed/wDfel/8C+PBHuXxJd7vQ87/AO+9&#xA;L/4F8eCPcviS71T/AJ37/tW/8lMkxd/zv3/at/5KYq0y+fHFGGmsPAiQ4CAUgkclnoed/wDfel/8&#xA;C+Dgj3J8SXe70PO/++9L/wCBfHgj3L4ku93oed/996X/AMC+PBHuXxJd7vQ87/770v8A4F8eCPcv&#xA;iS73eh53/wB96X/wL48Ee5fEl3u9Dzv/AL70v/gXx4I9y+JLvRFlB5r+txfpCPTvqtf3vpK3On+T&#xA;y2x4I9y+JLvT30IP99p/wIx4I9y+JLvd6EH++0/4EY8Ee5fEl3rljjT7Cha9aADCIgckGRPNJ9d/&#xA;46nlz/tpSf8AdO1LCh3kz/lD9B/7Ztn/AMmI8VX3XmnRLK4ktbm5CSxHi606HFVH/Gfl3/lrH3HF&#xA;Xf4z8u/8tY+44q7/ABn5d/5ax9xxV3+M/Lv/AC1r9xxVtvOXlwGgvFb3AP8AEDFU0tryO7gS5tla&#xA;SKUckccaEeO7Yqq82/3233r/AM1Yq7m3++2+9f8AmrFXc2/3233r/wA1YqvxV2KoTUdStNJtTeXz&#xA;mOFSFLAFt22GygnFUFp3mnRtVuPqlhK00xUtx4Muw67uFGKprzb/AH233r/zVirubf77b71/5qxV&#xA;3Nv99t96/wDNWKu5t/vtvvX/AJqxV3Nv99t96/8ANWKu5t/vtvvX/mrFXc2/3233r/zVirubf77b&#xA;71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxVNzFETUopJ7kDFXe&#xA;jD/vtfuGKu9GH/fa/cMVd6MP++1+4Yq70Yf99r9wxV3ow/77X7hiq4AAUAoB2GKt4q7FXYq7FXYq&#xA;hNR1K00m1N5fOY4VIUsAW3bYbKCcVSj/AB35Z/5aW/5FSf8ANOKu/wAd+Wf+Wlv+RUn/ADTirv8A&#xA;Hfln/lpb/kVJ/wA04q7/AB35Z/5aW/5FSf8ANOKtjz15YIJ+tkEdvSlqf+ExVr/Hfln/AJaW/wCR&#xA;Un/NOKq9l5v0LULqOzs5mknlJCJ6brWgLHdgB0GKpxzb/fbfev8AzVirubf77b71/wCasVbVi3VS&#xA;vzp/AnFUn13/AI6nlz/tpSf907UsVd5M/wCUP0H/ALZtn/yYjxVGzavp0ErQyzcXQ0YcXND9C5VL&#xA;U44miXIho8042Bss/Tulf7//AOEf/mnI/m8Xey/IZ/5v3O/Tulf7/wD+Ef8A5px/N4u9fyGf+b9z&#xA;v07pX+//APhH/wCacfzeLvX8hn/m/c79O6V/v/8A4R/+acfzeLvX8hn/AJv3O/Tulf7/AP8AhH/5&#xA;px/N4u9fyGf+b9zv07pX+/8A/hH/AOacfzeLvX8hn/m/c79O6V/v/wD4R/8AmnH83i71/IZ/5v3O&#xA;/Tulf7//AOEf/mnH83i71/IZ/wCb9zv07pX+/wD/AIR/+acfzeLvX8hn/m/cmGXuK7FVK4uYbSIz&#xA;XDcEBArQnc/6oORnOMBZZ48UskqjzQn6d0r/AH//AMI//NOVfm8Xe3/kM/8AN+536d0r/f8A/wAI&#xA;/wDzTj+bxd6/kM/837nfp3Sv9/8A/CP/AM04/m8Xev5DP/N+536d0r/f/wDwj/8ANOP5vF3r+Qz/&#xA;AM37nfp3Sv8Af/8Awj/804/m8Xev5DP/ADfud+ndK/3/AP8ACP8A804/m8Xev5DP/N+536d0r/f/&#xA;APwj/wDNOP5vF3r+Qz/zfud+ndK/3/8A8I//ADTj+bxd6/kM/wDN+536d0r/AH//AMI//NOP5vF3&#xA;r+Qz/wA37le1v7S9LC2k5lKcvhYUr/rAZPHmhk5Fqy6fJi+oJdrv/HU8uf8AbSk/7p2pZY1O8mf8&#xA;ofoP/bNs/wDkxHiqhf2HnCW8lksNUhgtmasUTRKxUU6EmJv14qh/0Z58/wCrzB/yJT/qhirv0Z58&#xA;/wCrzB/yJT/qhirv0Z58/wCrzB/yJT/qhiqvBaedYVKyX9ncEmvKWIig8B6Sx4qq+l5y/wCWjT/+&#xA;Rcv/ADViqHnsfPEzho9TtLcAU4xxVBO+/wC8SQ/jiqn+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8A&#xA;kSn/AFQxV36M8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M&#xA;8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp&#xA;/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp/wBUMVTfRrfW&#xA;reKRdau0vJGYGNo0CBVp0+FE74qmWKuxV2KpLrv/AB1PLn/bSk/7p2pYq7yZ/wAofoP/AGzbP/kx&#xA;Hiqbky12VSPdiP8AjXFXVm/lX/gj/wA0Yq6s38q/8Ef+aMVdWb+Vf+CP/NGKurN/Kv8AwR/5oxV1&#xA;Zv5V/wCCP/NGKurN/Kv/AAR/5oxV1Zv5V/4I/wDNGKurN/Kv/BH/AJoxV1Zv5V/4I/8ANGKr8Vdi&#xA;qnOvKMjjz9q0xViF3pVw91O48tPMGkciUamU51Y/Fw5/DXrTFU+0XSLSxjW6jtGs7mZAJYmnefjv&#xA;XjyZ2X6Riqa4qh76S7htZJbKEXM6iqQlgnPfpybYYqkv6W83f9WBf+kuLFXfpbzd/wBWBf8ApLix&#xA;VN9Nmv7i2Euo2ws5iSPRDiSgHQ81NN8VReKuxV2KpLrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/&#xA;AOTEeKpVquna/NqM8lrpOn3ELNVJZq+owoN2/fL+rKJ6TDM2YglyIa3PCNCRAQn6K8zf9WPS/uP/&#xA;AFXyP5HT/wAwMv5R1P8APKrb6Zrikm68v6fKP2RG/pmviSzyfqx/I6f+YF/lHU/zyr/o+/8A+pZs&#xA;/wDpIX/mjH8jp/5gX+UdT/PLv0ff/wDUs2f/AEkL/wA0Y/kdP/MC/wAo6n+eXfo+/wD+pZs/+khf&#xA;+aMfyOn/AJgX+UdT/PKaWGiWM1uHv9Kt7WepBjUiQAdjyAGP5HT/AMwL/KOp/nlE/wCH9E/5YYf+&#xA;BGP5HT/zAv8AKOp/nl3+H9E/5YYf+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf5&#xA;5d/h/RP+WGH/AIEY/kdP/MC/yjqf55d/h/RP+WGH/gRj+R0/8wL/ACjqf55d/h/RP+WGH/gRj+R0&#xA;/wDMC/yjqf55d/h/RP8Alhh/4EY/kdP/ADAv8o6n+eXf4f0T/lhh/wCBGP5HT/zAv8o6n+eXf4f0&#xA;T/lhh/4EY/kdP/MC/wAo6n+eXf4f0T/lhh/4EY/kdP8AzAv8o6n+eXf4f0T/AJYYf+BGP5HT/wAw&#xA;L/KOp/nl3+H9E/5YYf8AgRj+R0/8wL/KOp/nl3+H9E/5YYf+BGP5HT/zAv8AKOp/nl3+H9E/5YYf&#xA;+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf55RFpp1jYljZwJAZKcuApWnSv35bi&#xA;wY8X0imrNqcuauKVpdrv/HU8uf8AbSk/7p2pZY1O8mf8ofoP/bNs/wDkxHiqzW4ZJLdhHDeSn1lN&#xA;LOQRPSku/Iharv4ntiqR/Urn/li1v/pLX/mrFXfUrn/li1v/AKS1/wCasVTjStCR1hvpZdRt5EcP&#xA;9XuLkt9htg4FQQaYqyHFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FUl13/jqeXP+&#xA;2lJ/3TtSxV3kz/lD9B/7Ztn/AMmI8VXa5ZCW1AS3uLotKrFLaVYXFBJ8RaqVHxdK4qk0OjLIzCWw&#xA;1GABSwZ7wsCR0Uem7mp99sVU/wBFP/1adT/6TV/6rYqitPiudNnNxBpGoM5UpSW6jkWhoejSnwxV&#xA;NE1fVGdVbRrhFYgFjJDQA99pMVTfFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYqkuu/&#xA;8dTy5/20pP8AunalirvJn/KH6D/2zbP/AJMR4qq+YLQ3lkkQs3v6ShvSimEBFFccuZZa9aUxVJ7D&#xA;SWgkkY6NPa8o3Xk92Jw1R9gKDLQn+ag+eKoX9Bt/1L1z/wBxFf8Aqtirv0G3/UvXP/cRX/qtiqYa&#xA;R5ftjcCe50yewe3ZJIi92ZgzA1+ykjdKd8VZPirsVdirsVdirsVdiqHvb620+A3N3IIogQCzEAVP&#xA;TriqXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVd/i3QP+WyP/AIJf+asVd/i3QP8Alsj/AOCX&#xA;/mrFXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVbXzXoLMFW7jJJoByXqf9liqa82/3233r/zV&#xA;irubf77b71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxV3mC2GoW&#xA;ggm09b9Y5lZY3na3HSRefMAV+Xv7Yqg9F0HSoBJPJp6abOwaLit0bjlGwFd2NBv7VxVU/wAG+Uf+&#xA;WVf+R8v/AFVxVcPJPlVhVbIEeImmP/M3FW/8D+V/+WH/AJKzf9VcVTexsbXTbVLKyT0oIq8EqWpy&#xA;Jc7uSepxVEYq7FXYq7FXYq7FVrxxyrwkUOvgwBH44qpfUrP/AJZ4v+AX+mKu+pWf/LPF/wAAv9MV&#xA;d9Ss/wDlni/4Bf6Yq76lZ/8ALPF/wC/0xV31Kz/5Z4v+AX+mKu+pWf8Ayzxf8Av9MVd9TsxuII/+&#xA;AX+mKq+KuxV2KpLrv/HU8uf9tKT/ALp2pYq7yZ/yh+g/9s2z/wCTEeKo280fT9QQxXsInjLiTi2w&#xA;DDnQ/DQ/tnFUF/g/y1/ywR/e/wDzVirv8H+Wv+WCP73/AOasVTOzsrXT7dbWzjEMKVKoK0FTU9a9&#xA;ziqvirsVSjzLa3l5pvo2FfW9RSCpINBWu4zG1uPJkxEQ5uZ2dlx4s1z5MNPlzzcSSJ5AOw5HKI6e&#xA;QAuJ/wBOXKnqYGRrIK/qBr/Dfm//AH/J/wAEcP5c/wA0/wCnLH8xH/VB/wAqwq23l7zTHKrTSSOo&#xA;YEjk3QHfKsulzEjhBG+/qJbsOrwRB45CXd6AHoaAhFB60GbR0q7FUt163ubnTZIbSvrN9niaH8Mp&#xA;1MJTxER5uRo8kIZomXJhL+XPNjGqTSKPDkxzBwaXLGFTBJ/rl2WfV4ZyuEhEd3ACt/w35v8A9/yf&#xA;8Ect/Ln+af8ATlp/MR/1Qf8AKsL4/LvmtQeckj+HxsMx9To9ROuC4/5xcnTa3TQB4yJf5oD0G1Vk&#xA;tYUcUZY1DA+IArm2HJ0kyDIq2Fi7FXYq7FXYq7FUl13/AI6nlz/tpSf907UsVSnyn5s8q23lXRbe&#xA;41rT4ZodPtY5I5LqFXR1hjVlZWkBBBG4xVNv8Z+T/wDq/ab/ANJkH/VTFXf4z8n/APV+03/pMg/6&#xA;qYq7/Gfk/wD6v2m/9JkH/VTFXf4z8n/9X7Tf+kyD/qpirv8AGfk//q/ab/0mQf8AVTFXf4z8n/8A&#xA;V+03/pMg/wCqmKu/xn5P/wCr9pv/AEmQf9VMVd/jPyf/ANX7Tf8ApMg/6qYq7/Gfk/8A6v2m/wDS&#xA;ZB/1UxV3+M/J/wD1ftN/6TIP+qmKu/xn5P8A+r9pv/SZB/1UxV3+M/J//V+03/pMg/6qYq7/ABn5&#xA;P/6v2m/9JkH/AFUxV3+M/J//AFftN/6TIP8Aqpirv8Z+T/8Aq/ab/wBJkH/VTFXf4z8n/wDV+03/&#xA;AKTIP+qmKu/xn5P/AOr9pv8A0mQf9VMVd/jPyf8A9X7Tf+kyD/qpirv8Z+T/APq/ab/0mQf9VMVd&#xA;/jPyf/1ftN/6TIP+qmKu/wAZ+T/+r9pv/SZB/wBVMVd/jPyf/wBX7Tf+kyD/AKqYq7/Gfk//AKv2&#xA;m/8ASZB/1UxVKdZ82eVZdR0B4ta090g1CSSVluoSEQ2F/HyciTYcnUVPcjFX/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Example of an Interactive PDF Form</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">PDF forms</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:creator>
+            <rdf:Bag/>
+         </dc:creator>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>forms</rdf:li>
+               <rdf:li>flat</rdf:li>
+               <rdf:li>fillable</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+         <pdf:Producer>Adobe PDF Library 8.0</pdf:Producer>
+         <pdf:Trapped>False</pdf:Trapped>
+         <pdf:Keywords>forms, flat, fillable</pdf:Keywords>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj96 0 obj<</AP 17 0 R>>endobj21 0 obj<</D[22 0 R/Fit]/S/GoTo>>endobj16 0 obj<</Count 1/Kids[22 0 R]/Type/Pages>>endobj22 0 obj<</Annots 184 0 R/ArtBox[0.0 0.0 612.0 792.0]/BleedBox[0.0 0.0 612.0 792.0]/Contents 195 0 R/CropBox[0.0 0.0 612.0 792.0]/MediaBox[0.0 0.0 612.0 792.0]/Parent 16 0 R/Resources<</ColorSpace<</CS0 137 0 R>>/ExtGState<</GS0 138 0 R>>/Font<</T1_0 149 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 186 0 R>>/Shading<</Sh0 153 0 R>>>>/Rotate 0/TrimBox[0.0 0.0 612.0 792.0]/Type/Page>>endobj184 0 obj[100 0 R 118 0 R 101 0 R 119 0 R 102 0 R 103 0 R 104 0 R 120 0 R 121 0 R 122 0 R 105 0 R 106 0 R 123 0 R 124 0 R 125 0 R 107 0 R 128 0 R 126 0 R 127 0 R 108 0 R 109 0 R 110 0 R 113 0 R 114 0 R 129 0 R 116 0 R 117 0 R 111 0 R 112 0 R]endobj195 0 obj<</Filter/FlateDecode/Length 8996>>stream
+HâÏWÀ™«˝ï&É€™⁄ı„Åe;ì4àß‚Dëëà"ÚˇYkÌ]›Gå ì¬Ös{’c◊~?>˘H¯À«K9Îú´èuX]gÌπßπé«á£§£ñâU;G;ÍŸéæ;˛||<>Ø˛&Ô?É@=˚‘Æ˛•√@bçeu‚Ú8WÍVÍ πÔ~9^Ω˘5ü=~¯Â¯˛>}-’£5˚jÊ9€,e‡V*øÕ¡´◊†Ú ï≥,˛T˛î„¯¸¯xΩU\ñux†™r›*ÎÈÃµêÁøÚ≠7ˇx˚Ò¯Êõoø˝Ó˚◊«Ò√O¯˘$ =€ïm·˛”¡ﬂZ{ı«∑ﬂø{˜Ò˜_{„øY˚ˇkˇ√¸¯∑˜ˇÇ]´Ø~˛˚€«ªø¸¸˝è«´ü^ßCã_xµŒ≥èq‰÷ŒÖ*ÛÃs{i¬RS‡~ÛéöM∏uÏ¨¥J?Í∞sÊnkUÊ˛á„%üi|‚cµuº§séy!ˇ˜∏0($#™÷…t#∏BæÅ∆Í<ú⁄ÒROKù®u#ÍV/‘ŒÑÃÙx¬KGGËÁ¨UúA¶óÍ’Y®êÓeûu8gΩ!ﬁS&_≠L„…rfPÀÈ$ôrŒôÖñÒ1)A>≠n¢k°Á≈«+	Rº^nÙ •ﬂ€∞D+õ`Îª§C
+¨˛t{≠MÁKøemÙ–ù|r◊Œx∆$l@˝{‹^#MÌª‹Æ'⁄é|zç{ÅúÃ!ògó˚π’ÜÛ7—~"‘è—˝¯»óN=®≤4÷Ω]°pgnyÖ	¨BSö™ìã˚P’.QrøÓ
+Ø+$ôI§ﬁÈ·Ωà·>€Aq•/
+ôœÊ‹’Q f.dç˙∞ù. t!"CN¢;=)ììõÙqTm-∫)òÑûÏÿËÅ√p™ä≠$C°XN∑HFL|ê"Z◊
+Ô≈ŸÊ·XÎ«Ω0N[Y◊3m—·iÕï\≥‰tu—d¥pÉ¬ÇÙπ•‘g·∑`∫‚0U¥:ØÖRWìÈ¯¯TrP®Äµëä$&zaÇŒ«viÑÎπ[ê—ç√E˛X®¨‹√=©–$:≥Ñ£ÒKNFØ“2B¥”®Ω)^|Wgˆh¯‡#CbvÂ∆$sõY œ‡ ˆ@#3õ˘7Õ›ï∞@Üæ/9• Ëø%ñ⁄ˆ^FÆÇrß¥]–6AµNπñƒ^RÆÎà` Ù).Ø+[›bﬁç‚™$-0’∂¢Ïâ‰º<K,4A`ºx‡1 aäd€#a-Ê]ûm∞¥¬é^4ÚP¶]N∏üy…Ô—º	*ÉŸ?‡ÌM◊¬`™$É/,AU–≤<9’æèõã≠ºünûa◊ÖÓ8pº√§!ã‰ß(˙2Œd∑í¸ ä)aù˚µ¿⁄µñ‡Ç#;›ﬂC‹ÚÊ∏)®å)–ëlµÍ∫∑¡F!fwì§*(5B©ÜÊ…tDä’πúT<éu=Ú·˘°…DÒ‡©ﬂƒ8 ‚RçQ-S‘¢Iå£©‡Éêo>¡€t±@”vAc~Å·≥â˙íöëƒù˙î X(*D0ö)éfœpS˜Ö®Ô∏\:Cº®É—∫9'´l¸b–‰X˚f†õΩPË˙Ädê|‰&hUﬁΩzç„Ω´]PYµ‰FÜíyl√ˆD]∞boò*XÈä`t&7v±yÈºD<6	öIV,À„g©}BÆ(ﬁV¡˛⁄{zÇ6)∫+¬en˜´1Y¬ﬁ÷T6r®¥ﬂïY¿3Mæ0<∫UG’ÀúôõnÕàØÚ`Zùû3[Â~áìCuc-ﬂ¨}Ãu°«Näπ∏ë¯e§>∏càV\¬™˙áU6TÉRCd‹[Ö∆kCô¬#gXÄ˘çªF˛*kzÅ…
+A4EﬁØN*÷4ÜJ-:kŸ-√ö2{ç[¿‚•¨—µ–ƒ›`é€◊ôé«u¶‹j˜Î¥tæX„r™58∑À„KHÊçqÂ3ÔΩ©î§nE’“UF¥“ÿ⁄t8∑Æ˜>˚¸z_f€eudÅÏº‡m(ﬁ=Gp≈G˛`íg∂Èë X€·¥Qf†pî∆÷Hf®ˆ(f‘˛Â¥∂>)¨´;ê<<!{Ô]7’æIC6'\’¶eÛGªÏ?ùwçÕ®Xî¡¬°\8˜µ-xx!µR∑ªRcÛKﬂ}Ëq÷ÂÇûáû\2k=ãÙÜªä∆T~ê!PÂM^\.Ì`´íóLu7&‚±EÎnˆlÁnØ$ßúh9ˆ.{mƒÂæ™öìü(≥÷‰∂ﬂï-Cëû”ºò•K4D≠"˜ŸæJ(¬ùèy ±¶±S«•πTΩ%ÀÔÜ∑#∆¬˙wUﬂYY@€–:Êˆ€ZBñlıàõu±Õ∞j˛Ä§ä8OQËw$«4C≠»ÁÀ‹CóhèW*Y…e›ôÄpx1X"µ–∂Ω¸vkﬁ‘7mù>`¡õÖ8Ô]ônïêmµ*Òã⁄õΩ˚ñjîÍ4Bñ–úIçıjéû⁄ÄçÕg(ø 	l|· j«ÛX˚‚á'lﬁ’Zﬁ¯˙p“}ô”ÔpÚ“º©DËyï9ÅsKÃ›¸hœ⁄\MdGÒ^ÃˇÕÓ¿íì”Äz-Û,¢∑iN s◊E}Î`E;pmıÁK√N´¯Iç≤Ò‡D÷/fP&ü9e2ÈóSÛòD*≠=) —„Û®‘√X2W]yB—Éf,ïÎ&}s\toûÎ„UxMaÃmıb˝E∞+Y™∑!'ÚCØó8°T◊ÇåPî∑ˆÄrøºﬁ—„R˚µõòâ„&€®'≤aÕx4,MÜÍÂ‡∂ÜÀ‘≤‰ÀÅ™µ·^‘BúïÛQGÛrÃÍ≥—nÎízdì˛
+k1
+ê^ôÍÈØ[PGth Ò]Íz]7ß⁄;QUÚMÍ.Q™äÍpÙSJ!îL	≈ª;ï]ËÀKõÍ…KÚŸ¶∂È£ Óıu&4Lzhj∂ﬁ˛µ–Çö.”õÁM™#éÎq&–yqFÛÁªª+Qn	ùÃK^xòıKl*∑èf·‚iHZú"a:7’0@lÜq‚"«∂g≤ê }^è6ıŒ-_üx≠>1P9T©óêP§'O¯p€Y]Cr•{™o>°–n‡P~‹t√Uöm9zVu;aÚ5J+.ñy;V≤õnÿÂIOæÀ∆%#∏`36†ôÿ≠LêDë7v1=S8« µCúHëÆ¶zﬁöŸáü˘ª¬Éo‰g(∫I‹NüÉd.ˇñaG∫∂Ë.ìõEï’»å=d6«ÏxrˆvucÕ'ûÇ‡Ë°ˆ0ózÌÕ∑ÃHÂB+q÷q“lÍ7õèÜA◊Q WﬁªP„Ê]íPiÓﬁc¥É√õRpC† ≥Õ(˙Ò-kı±!Û⁄Ã“©ÿ&À%ÜßLVö±∫f4KH^–6Î≠—b ¨µ¨∏5≥≈∂Óì
+>'ò·ƒk]ÌbS∞ôù¶Ï[”⁄`ªh@dG5öN`‰…«m*`ª˙?4(YÅ6Ë=ö1K5ˇ§]õŒ8ÄP≈˚$h∞ πòc–+Â∑ÔL„ÛY —E”ûû(†K-‘„ﬂÃWYédπªJ^¿ÌÀ1¸Â$l¯#k €˜$CzzY›œ`¶‹h†Î1µK$/À∏6kSD-I8Xguh∑9!§3RHè<y>˛Ò¯Î„_3cˆèj˙<·øRAπﬂı„ë√√í¡◊lPUâê‹√øˇ˛¯€„Wõ/Öí∆.[ˆ<˛Û¸uOã›sØm◊óñ,Â˙ú®I>ÿˇ√Æôtø(!¶tÔl˜/º~KÔ0ÿ◊?uôù’ãÈ√C~∂È¯µÒd©zañ˘F4àa(#Í%∞–ª]ãÌ¡Çö˚…›¯VeÓ∆còvµu÷eÉ5x·} µ”O?áZæøˆÚÔ¯0ÿÚé˜Uj7ìú∏ˆyûBÖf0Í>66©…ô®õV¿ˆd:ˇ“ì#@pE¬Øç!ÃS?h¿ÒÉÊÛ÷b8Ç¿!“≥ÈŒWÀˇqÏ _4õ≈˛^'õ
+«Ü*m‰µüg¬kr´ƒ⁄âR©æ?çBªÈt¸Wl˚◊´¯ê„á§ã’(è2‹»on®„>7÷^#Á5∏0~Cıî ÜçµUÙ±M|ë˝ó:ØuÙË◊:∫¯k¶F›õˆsæ› çmC˛>6∂C°{∂-Ä4A$ %„®ô F’*´}òf≈=XHS?7ﬁqæ⁄=k}Æï”æ÷ïÛæó›Ó_£èú_¨úœF‹::r©S¡ÊYÊ`Á¸j‰Œ_€1b◊g¢9È◊≠ÍN€ÏW;4-_£ØkæÆ≈€π3ü 7};4>–G\Q]m…è®ˆÆ .¶Q#˛Å9ÁÛ9Ö7”ÒzÊL370w(µ ‚iö√E ªô˘⁄ÿn¢áπ∆$ã"÷Zq¥ÒÀ§z´Ω¬—!≤‡’≤π”Íº≈≈fÀ©¬õëõyÃkæõ»ÄM’…˜Õ∑Z¬AÕOïz5g2íç+8⁄¨‡xgÎjw≈\RArÏz¡ß6÷ÆÊ¿iÕÑº7ç©ÎÍÀAŸ˙⁄óÙ˚V6Êl@ë…ŸÈµ'´ ’>|ˆÿò)%¬ô ∑–˘:såB√»¡Ó∞ÿ¯VkµùÊœÑÑ∞?‰≠0ÙßÒOî8¢aüZeV÷ò⁄®„°≥wï™GıZ’Ïa>Zc≠k&†&D£i8µ±÷Ö)¥¿⁄†œû§€® HﬁX|w56®$ßsÜ‚çs¢‘ÂHßˆé£hË$¢,Ω] y˜\–∑ò§y0 Ïô{\Ë);õÊ}Â±€ÅDAµˆ5eƒÖ-_8óÉ"%T«Q∏M¬`¥rƒ-s	·◊>ª˜∂to¨gI,Éx'˚Q,lëZÒßMR@÷6Ãd‰t¢û4ú¡Öã^◊2⁄¬÷ÁO∫[!m—"ÿ1∑{=z[Æâ,W©Ë¶z‚^íÙ‚L%D¶ ª6cÍ£1UæRãBç;
+å4[·Û"∆≤Ü£äÉäu°6|¨∞BûãrnÓw5÷G˚Ó≠
+„k∆…r–ﬂ∂CíÑxüL0·Ô#ÏvC]ó4Î<P(\¶¨kôÅèÄÁÙ≥± ıh);,¬‘2LY+';#-öHÈ“¶FER∫……∆®ÄrÑ3<OÃçå∆å`éÊ-qblõV“Lö—É‡Û<êO{aÃ‰[Õ¬ÆQfeåÆÆŒAÆ¯P^à[iÖwùÈ—Fïÿv|≤JÌT`X.xWT≠TH{N„VŒ€ıULo\¥›M2=∫Cn¶ßãÊª§ªnÇ«üT∫˜ÿÏäå´ª∑°“$7‰òX/∏YP8˘ ‡€"˙<Ï†J÷‚H|◊W£sf€t+ßø·^Æ†ÜÂ.Oÿ‚˘aT1f™
+¿èÿ££ƒ%Gˆ]˘]«ı:«Å‰^_¯¸	°j	Á™|º©¸÷¸o™|˘*üOïœwïè?P˘˙ì´¸M‰ﬂ4˛M‚ÀõƒóH¸xì¯›˙Mâø)|∫+|yS¯rS¯rS¯Ú¶Â7(|S¯Ú}ÖOo
+ˇÖo
+ü®È¶ÈM·”˜˛M‡„)ı˜¸)ÔwqøI˚©Ï∫çC⁄˚$Ì˘&Ì˘M⁄˜ìB⁄ÎM⁄˚õ¥ßõ¥◊õ¥◊7iØß¥◊õ¥◊7i/?íˆSŸ€]Ÿ˚]ŸaOVi&ì8;u©ÕÚ.ÿ%◊É‹ı2kõÃÈ c∑øGó29ƒ#2)@∆⁄%)òÎTà;móêtŒC%äÚ≈ê>®ÖçûæÚ—x8AÈ`Ãö∫z"gˆı∏ae/¬‘_gƒ”∞Y0∆æ{obd¡XHT<≥∞‚=7D „àG^,‘|(†ÂsTïDêv"≈E–°0	úËΩ„ÍÅ≠eÊŒ-5óoè|FÏo)gYH*[ÎŸöÀâí–t¢JxßJÆ‡+R“Í˝TÑf>PΩoúÔπûéUågªˆûlÍÎUÕvy‹ÉÔi`
+a7ñm˜vE®´˛Ú{ö—)ÃÒjsâ>©˛»Ú†¿JÁÃ†¥‰öI‹[òo´Ù.àë«'‚}Å‘’/!ëbçY˜¸≤Ïœ›∆ñ8Õh¿⁄ı:Zhﬂtı2t€∆„O‹&^Ôî€aÍwíπÒÚ$çr&|ê¿7Âª•Œx º∂T^0|Qöá∂ïo⁄F◊¥µÕ]à˜6T˘ÊeﬁPÒBd·µn’∞Ø«^Ô8…?’æO®"„V‰ît‹áMÿ˜îÎv J´»°(∂∆ˆ˚ä4◊¶Ï¡5;ı{Peë©≤®é3\TºøweQˇïEø$≥{ä¿P{òñ@Gq‹•Ü=É~Ë√˝{WfÇØÂ{Ω'lˆ£—Ô#8n¶m‘_'ûwLk•$^ R(®ñ£ÓçÖ%jq∑„’%F≠+çDë¢=;˚83xŒ°TQ˜Ë¥e®»,>9— ØXìd
+@RùTK”€π÷∂óãrr…8eD·EΩ.Ò8a«ıSØãØ.©ã‡ªËXÜGáÑ~ªËOióKç)âG}µí;:9¿¶ÔR9ó7~mŸÙﬁIrñTY&I]¢™äòí…5ñ∆√˜h®Æ„Ä·S:kô“qÿÌëŸ;Ô√Œ|¢≤,≠„Ω¨]|§#ÑãlU¸2Ò=Û˚πÙìOÑjà °@õ≥ø)°ø»lnÄÎârﬁ+6øé*úT®w@±Ã`˘n4 	Ax∏/$])l UÁ¶ˆÿr∆˛À2Mô⁄ò◊ÎgÍCÕâﬁgπª˘ÂÂ‡ÊÃ1ík◊1,‹¥¶£Á∂∏¬Lã9Øﬁ∂—4ƒÎcªdmÈy±B§}ﬂ!£ÇwwOCyî=Œ√4wN&ÇaÊJıJãJV4‹Q&£>ºZ3Qñ„EX_g»ÚõÎ0Ω›≈àyâ8m3Æ¬W@ûV€Àô]»»!∞ŒJ≈øœç‘'úU§êÔgˇ∫ËnÊaZFh£è…ìQŸ∑Lñí“ùí€Ö¥=◊Û‘ìÂ≤‹náñu£xÜÃÊ;*FÙ§öê´d ƒÂFRl«*Ö˜u≠bt8ùNa‹W«kIªnsÓc8¨Â·f<ìñLúY@v–ûNP4û8nIâ≈[b.æñ5›kÑ5ì¸eX≥Ü€
+vk)Ì$£BëGlÙî˚;Nq&ë˙¬–±Œ6Ìú˘çûÙ›Ëâ˚Á=±ÌwuøÎÖÙÆ¬¡/y‰€ù∑t‹y∫Óº‹Ô¸vÂ˘ßΩÚﬁë≠…\I©Õ™“`“])‚Ü®ë›Õ$∏ª]ﬂ£ÀQ;Ñ¡6–˘3cÈí“2ñOq=Âu¶Ãc[.∂ì-Ú~$n°ßØ|4ˆ£ÿÍ≤v1ˆ2°Ù±—√ÜÏΩãµÌ¡F¨´ A∞wZä ™Pñ;^êQ4k%¶=Ó	∏˜5	ƒBÆÑêù(u`›G…ˆEÖû€‹	3ñ·‚WÔ-o‘±∏t'ó≈ƒ ÷˛ó˙jÌmπ¢˙ö¡è‘3Û~ ãô∂’⁄í+)m∂NQäªp‚ N∞›?ﬂˆÃÉ"á¢hôvãmÑPã√˚ò{œ=«+Wøí∆Ñûê’*‘ΩîÕ_—≠VÅÊF!Çí∞ﬁGW¯wA≥Ñ!@⁄[È1π^—ä2«µ”ûı¨ñ$ôˇ≠ˆﬂ=´¬≥4—ÿÄ,¯V>Oûsáu–°l≥vCù{;⁄äÕJÄ∂òÄÂq]˝xØÚG&Èï<ùë™™ÇJ©:°»∂cπA#–([Ò
+Ïîl∞]…¯X jÅájÛøÍ~#ë{"≠Ói[∑ø$j”˛Òæjˇ∏åÌoöÌHv›˛B•Ì{:∂ø—	lV°˝É8çø∂˙ü•˝/7xÙXˇã@‘bˇ”∞g”ˇ· Ω¶≠±]™•,[Ÿj~{µÊW.¯ı¶ƒYÂï◊°ºû"æ:7¥«Øe†.q¶ß‡=Èlºcüﬁ·s≠£Ÿ4É{˝∫2Ë⁄!®2@Ñk÷XEÕPØâÿ– 0+Ê¡»M„ l“CLT&5&Z≥°_ıä»®D™∂˘5êäƒ)tq@fpâù™x?•ÉÙ?YÇüJÿ~F˜†∫Y	yD\{$£ı7F÷±ˇÉGƒ/=R∆Ï√3YØÇJZo÷$ÃÊÆ@√i4D4∏≠Q√¥Q£<üd·ÚßÏıdI≤…“=∑8»≤ÂdÊ˙5˚5Ÿy÷ÄŒQ
+E¡‹Ω/≠
+g0Å˙ºh	oVŸÎÂ◊´/ŸO?˝¸Ûõ#•˛„!Êıä˛›Ωtı—Èù≠÷ôõI∏πC–àTYœÅL∂˙ú]Êßoœ«î‰á3wÕ‹eQ.Áo„ûO ÂÊØÒ©√1ï˘Iy^ŒVõüñøå)œó´Ú|¸∑’bNV‘ŸVÄúé Ÿ
+¿’Nò«S=ƒ†ãêl˜ÌÚeP⁄úa^+˜ª†<ø8sõœ«Ã‰øåu^ñµg¡°G|y}∏˛˛„Ínu˝œÔY˛ØènGüF_FW£Ô££o£Îq”◊ƒçD0Ø‘°È	≤§uæzª(+˚uù¥$«~TÆ$oj?ı|Oû¨
+Ù¶ø·•_ˆz-íD1Bçª¶–s(k••ÉIÂ≤îœ∆´<˘`Æ€ıËæ?‡É£=åí„I-shUÅnnZæÃ«"?è5‚éáÈ¬2'dW≤¸Ëıøåﬁ’a◊Bø6ª◊Ö≈ïo^Ìƒòî¬6iﬁ∫wª˜·û2Èßm˜∂Ì‹6€›¯Vÿ¬ç
+â=ñÿá˙l∑Îm…Äˆâù√Âj+I{w|W<ä«ó	‚ÒH‡^<µ4]ºp“ä˙ÌÁ√‚p’}◊<‡5N˛%∂¶GGge3î÷&âcAµìMŸ_!Õ?FÒπ›È¢tÛu€’ò∞6∂€ÚÌÒÒ¥«iF0‹¡nöØπÃﬂ’Õ˚tﬂøz‡ËÛùZ'TÀj6>`Üõ¸bQ¬Á&∞∑˜KGŸe+¯wÕ0õ$@9E˙tÒ”–D !lH@&
+≈˙†§¶%t´ú^ïgÂ≈È|V™ìh6pÿÇ%'÷≤V%¥—‹)VõÓqÛøÙdÂ§úM‹˜/õÈ?3öœAT¥Ã=oô∏Ãk‚2ùœÅÿ¯Å=ùœís›∫3	°áõ8e˙lÌô»ÌË~Ù•o‘!üπiÛ2?zãê≈éËû
+u&8œihÉ$¿˜ÑÀ!1ﬁxæu„áyº&5X:®VbÚtzrZ¶¯›⁄Êö¿RŸruÍmr”åÅ¬Q:5”«ç-n^”ÚÏœC<ª›ÌˆåSËD•Z≈x÷Á7Öq}ˆ¸ú]Å3~ÿÌõÄ,r™/1t8;ÍsN.‰=ﬂπﬂê∏´—∑›ÓI]"l´ßºƒ8\lÄ∆NMB®›j—=îPÇ•-%åßPNŸcC†sÎctí8ëµæ$xRÂ¸rHÜÔ^∑»Ò›#¿%-O¨]BÃ0‚Ò(ÌØá˛z÷N{˙2Eë'—r}Pq<†8÷^ˇALç~Î	@ÒBbh∑XzwÀFo˝u—ilvíµ7$JLaπí/”ó—}Oxw¡π†≠@fﬁ’˘#N2î!7-'ã,-˜='™òπ™L1	‰ùõÙ˝n‚bÿñ¸XΩ«ˇ÷û÷±O—JâC(ZM’1”˘|1¶t˚ SHPNã⁄≠ƒSs‘« Ø˚ŒW[∞&.:
+âÇ¨Î,2Úˆ–jµ´¿ÿ“∂u“ÔÜ…àp}Ns®#ÎpZ\´‡4àN} e©
+≠©yÅ~∫}Ïq]Hè≤≠|œè{”+¥„≈≠x/[}3H‹¢¬øèn˙5NÆ–6ÇMU6_ùvq∆é¡%8ﬂ_ªBPHmÒà-Ñ¢ä`‚ƒ}≠»®ˇdÎ/ıÿ√{ç¿ÑEŸRK–YB¿C=1¡˙Ó`–IL≈xÆÎ¯-QD6>çÂŒ@¯^gÕ?4ü?H_u–¥rPôvüuˆÒ9qˇø{èy†ßËUƒIÂÒÖpOAAæàµxéÈO›Ùw◊rPºj°|√§®bbõ©›ú˝É˝C≠´D2‘BàÙ∏zÙ¨l)—™\üÙ•Á∫†≠Km]ÉRˇ◊{NõB+n	˘=ñ·K˜‹Ô:ÿ'ˆ\≥˛\˝0"b˝	–7W¯É’=U{ $¶ÑAÛ‘‘|ÜÒ“÷zçMäVô‘øÀ¸µkêj‡[–.,˝ﬂ∫îŸ†ƒxU≈u¶PÃËÿöÀ’¢°ß
+§oê	≤ —é¥¬7≤O dH˛∑EJ
+4§‡6µsŸ/BíÌî/qscÍa=NÎ6≤´:¥™’2F%% C:ÇÖ
+$Ûˇ¸Ì_:Ïb‡qv@:ëƒÙíZJULÍt~^∫˙Ã^xp	„ò¨H¨ı¶åJhUÍR÷‹Òó˘‚è©©P–=O(ı¸NBÅ í∫ÅÇT–~”∆ó∂	‘PYh	4u®˜¯Vw∞L—˝∑∂gG3ã≈·∏òg√d„ÁñXi7ô5÷&Ü «"?ﬂ“$iÈK7kXÍ·∞˛Ÿø›yYuÎA˘atÉªØ=}ßÅöË0N9§WîÖó˘¢<˙j:ü-Oß]≤‡P+ô>Æ°`˛‚t>+ªKíqTn¨+ê W7µÅë÷…~®·Éˆ5N◊64”ìÈÁ∂@ı
+n†çúB¬~Å€ò1ó∆O¯Rj¸/˛LœkÅ‘∫Åç{¥‰¬7„õw»Û…n≤Úºÿ”ºì¸ïÓÈ¶08	µÖÖi˘√!¡¯ê_¬ÿf¸©¡3TÈÀå	˛%|¿œ dR≤Ω"7¿√9xUz?€√õÌ∆1ü¨˚s∆».Ù∑t3s:w]tUÔÛc∏mŸﬁ{fh3e3ê˛ÇJÊ‰È0bˆ©è;–,µ3=È#≈R†|$O∑£5Ü√=>w;ƒhÇ2µ∂úúŒÁg=>k≠£Îœ˜ÒÉ^h˜ΩW;Ω4 çQ’¥wôM/Œ∆‹ÊÛsGæü1∞∂àªc zÁ)Ï˝Ú]Q«øBÏ)ŸË‚õõBÖF≠#_-∆†øGΩ¥CZt`kÎ∞CZÉs|Ûå„#˛Ø=˚ÿÕì)¥ÂÚ§ÑœÏ‚x:Å"…◊(áöpœ\øÇ√Ë |Æ—™=ÙN;x…ÄFØ≥1„äç—|~vVûÙ&ÿIÄã[Ø@qæ'úÖÄÀlêL∏ﬂÈπffª˘ºø}‰^Ú¸¿Óu9uîtw^çpﬁ•Y…è ìEô0¿g˜‘´!•YAà≈·\ªªπΩ¡È"Áts√·0~@˘≠—7˝]ÉC4T ƒ"ƒÓr>ôvµJ[¯Ã€v¯=®ƒ üwzI)Ü∑!*µ≥Ïì§ÁO∏ËŒ˝ãW€hØö÷b(¯Wˆ∏I^>èµZ,î*’õß"B≠-≠ˇüN"àŸÓ∆u◊E=dﬁG&oÊÖ¡≠}5¡tk–á‡Ïx5ÃÕÙ° Â:e8q:xå´8}~`“Â"^£±ÿEŸ˛…1Z:“Iºë–Â˝|vTÓó<©±@y≠“åá 54ﬁëK„\"5nﬂ‘7 R√ˇ¯jÇêZ0«…f(’ì‘¡‰aÇühe}Ç O‘t¨4WÂ—Ú≠÷≥,É<÷H≠tÇ1Å∏`ZIì∆…àkF&Põ˙;Ë‚Ë•Æ&x{1aÇ©´Í&˙F•_∞°ª(¨Ô¯Ω•>ZìI∏2-aM©\<ÃV´«≈Û›Sv(Ibd≠J†º9©7 §·n~sß5Éüô¥eó¢ﬁK¡tëNä4∆<ÛHîaJ%6%çÒÙß#©J∆íõj_~f—í^˝7—Wu‡µ±Y1\•√jôDZœ1…ö[Å]§≥Èôé§nÙî˚“'Û“él ÈÎõtÂz$m–Ô∞á6≠r"~äﬂÌ9ä,ä11Âú7»
+Æ’√ù/∂üƒ4fàá÷©¬0OÒKÑä&HØ=Ñ¥N˙Ñp= ÙñøÇ—Åcz›±ä·9Ûä˙ X«ıB¿ f∫ˆ!vÓXC∫‡±Pm å—xendstreamendobj153 0 obj<</AntiAlias false/ColorSpace 137 0 R/Coords[0.0 0.0 1.0 0.0]/Domain[0.0 1.0]/Extend[true true]/Function 152 0 R/ShadingType 2>>endobj137 0 obj[/ICCBased 82 0 R]endobj152 0 obj<</Bounds[]/Domain[0.0 1.0]/Encode[0.0 1.0]/FunctionType 3/Functions[92 0 R]>>endobj92 0 obj<</BitsPerSample 8/Decode[0.0 1.0 0.0 1.0 0.0 1.0]/Domain[0.0 1.0]/Encode[0.0 63.0]/Filter/FlateDecode/FunctionType 0/Length 206/Order 1/Range[0.0 1.0 0.0 1.0 0.0 1.0]/Size[64]>>stream
+Hâ ¿ ?ˇˇˇˇˇ˚˜ˇ˜ÚˇıÌˇÚÈˇÔÂˇÌ·˛Í‹˛Ëÿ˛Â‘˛„–˛‡Ã˛ﬁ…˛‹≈˝Ÿ¡˝◊Ω˝”π˝—µ˝œ≤¸ÃÆ¸ ™¸«ß¸≈£¸¬ü˚¿ú˚æò˚ªï˚πë˙∂é˙¥ä˙±á˙ØÑ¯¨Å¯™}¯®z˜•w˜£t˜°q˜ünˆúkˆöhˆòeˆñbıì_ıë\ıèYıçUıãRÙàOÙÜLÙÉHÛÅEÛBÛ}?Û{<Ûx9Úv6Út3Úq0Úo.Òm+Òj(Òh&Òe$ …^ã£endstreamendobj82 0 obj<</Filter/FlateDecode/Length 2574/N 3>>stream
+HâúñyTSw«o…ûêï∞√c[Ä∞ê5laëQIBHÿADEDÑ™ï2÷mtFOEù.Æc≠÷}Í“ı0ÍË8¥◊éù8GùNg¶”ÔÔ˜9˜wÔÔ›ﬂΩ˜ùÛ †'•™µ’0 ç÷†œJå≈b§	 
+  2y≠.-;!‡í∆K∞Z‹	¸ãû^êiΩ"L ¿0ˇâ-◊È @8(îµrú;qÆ™7ËLˆúy•ï&ÜQÎÒq∂4±jûΩÁ|Ê9⁄ƒ
+çVÅ≥)gùB£0ÒiúW◊ï8#©8w’©ïı8_≈Ÿ• ®Q„¸‹´Q j@È&ªA)/«Ÿg∫>'KÇÛ »t’;\˙î”•$’∫FΩZUn¿‹Âò(4Tå%)Î´îÉ0C&ØîÈò§Z£ìiòøÛú8¶⁄bxëÉE°¡¡B—;Ö˙ØõøP¶ﬁŒ”ìÃπûA¸om?ÁW=
+ÄxØÕ˙∑∂“- åØ¿ÚÊ[õÀ˚ 0Òææ¯Œ}¯¶y)7taææııı>j•‹«T–7˙üø@Ôºœ«t‹õÚ`q 2ô± ÄôÍ&ØÆ™6Í±ZùLÆƒÑ?‚_¯Ûyxg)Àîz•è»√ßL≠U·Ì÷*‘uµSkˇSeÿO4?◊∏∏cØØÿ∞.Ú Ú∑ Â“ R¥ﬂÅﬁÙ-ïí25ﬂ·ﬁ¸‹œ	˙˜S·>”£V≠öãìdÂ`r£æn~œÙY†&‡+`úÅ;¬A4à… ‰Ä∞»A9– =®-†tÅ∞l√`;ª¡~påÉè¡	Gp|	ÆÅ[`LÉá`<Ø "AàYAê+‰˘Cb(äáR°,® *ÅTê2B-–
+®ÍáÜ°–nË˜–QËt∫}MA†Ô†ó0”alª¡æ∞éÅS‡x	¨Çk‡&∏^¡£>¯0|>_É'·á,¬G!"F$H:Ràî!z§ÈFëQd?r9ã\A&ëG»îàrQ¢·höã —¥ÌEá—]ËaÙ4zùBg–◊¡ñ‡E#H	ã*B=°ã0HÿI¯àpÜpç0MxJ$˘D1ÑòD, VõâΩƒ≠ƒƒ„ƒKƒªƒYâdEÚ"Eê“I2íÅ‘E⁄B⁄G˙åtô4MzN¶ë»˛‰r!YKÓ í˜ê?%_&ﬂ#ø¢∞(Æî0J:EAi§ÙQ∆(«()”îWT6U@ç†ÊP+®Ì‘!Í~ÍÍmÍçÊD•e“‘¥Â¥!⁄Ôhü”¶h/Ë∫']B/¢ÈÎË“è”ø¢?a0nåhF!√¿X«ÿÕ8≈¯öÒ‹åkÊc&5Sòµôçò6ªlˆòIa∫2còKôMÃAÊ!ÊEÊ#ÖÂ∆í∞d¨V÷Î(ÎkñÕeãÿÈlªóΩá}é}üC‚∏q‚9
+N'ÁŒ)Œ].¬uÊJ∏rÓ
+Ó˜wöG‰	xR^Øá˜[ﬁo∆úchûgﬁ`>b˛â˘$·ªÒ•¸*~ˇ ˇ:ˇ•ÖùEåÖ“bç≈~ãÀœ,m,£-ïñ›ñ,ØYæ¥¬¨‚≠*≠6Xç[›±F≠=≠3≠Î≠∑Yü±~d√≥	∑ë€t€¥πi€z⁄fŸ6€~`{¡v÷Œﬁ.—Ng∑≈Óî›#{æ}¥}Ö˝Ä˝ßˆ∏ëjááœ˛äôc1X6Ñù∆fmìçé;'_9	úrù:ú8›q¶:ãùÀúúO:œ∏8∏§π¥∏ÏuπÈJqªñªnv=Î˙ÃM‡ñÔ∂ m‹Ìæ¿R 4	ˆ
+nª3‹£‹k‹G›Øz=ƒï[=æÙÑ=É<À=G</z¡^¡^jØ≠^óº	ﬁ°ﬁZÔQÔB∫0FX'‹+úÚ·˚§˙t¯å˚<ˆuÒ-Ù›‡{÷˜µ_ê_ïﬂòﬂ-Gî,Í}ÁÔÈ/˜Òø¿Hh8m†W†2p[‡üÉ∏AiA´ÇN˝#8$Xº?¯AàKHI»{!7ƒ<qÜ∏W¸y(!46¥-Ù„–a¡aÜ∞ÉaÜWÜÔ	øø@∞@π`l¡›ßYƒéà…H,≤$Ú˝»…(«(Y‘h‘7—Œ—äËù—˜b<b*bˆ≈<éıã’«~˚L&Y&9áƒ%∆u«Mƒs‚s„á„øNpJP%ÏMòIJlN<ûDHJI⁄êtCj'ïKwKgíCíó%üN°ßdßß|ìÍô™O=ñß%ßmLªΩ–u°v·x:Hó¶oLøì!»®…¯C&13#s$Û/Y¢¨ñ¨≥Ÿ‹Ï‚Ï=ŸOsbs˙rnÂ∫ÁsOÊ1ÛäÚvÁ=ÀèÀÔœü\‰ªhŸ¢Û÷ÍÇ#Ö§¬º¬ùÖ≥ã„oZ<]T‘Ut}â`I√ísK≠óV-˝§òY,+>TB(…/ŸSÚÉ,]6*õ-ïñæW:#ó»7À*¢ä eøÚ^YDYŸ}UÑj£ÍAyT˘`˘#µD=¨˛∂"©b{≈≥ Ù +¨ Ø:†!kJ4Gµm•ˆtµ}uCı%ùóÆK7YV≥©fFü¢ﬂY’.©=b‡·?SåÓ∆ï∆©∫»∫ë∫Áıyıáÿ⁄ÜçûçkÔ5%4˝¶mñ7ülqlioôZ≥lG+‘Z⁄z≤Õπ≠≥mzy‚Ú]Ì‘ˆ ˆ?u¯uÙw|ø"≈±NªŒÂùwW&Æ‹€e÷•Ô∫±*|’ˆ’ËjıÍâ5k∂¨y›≠Ë˛¢«Øg∞Áá^yÔkEká÷˛∏Æl›D_pﬂ∂ıƒı⁄ı◊7Dmÿ’œÓoÍøª1m„·l†{‡˚M≈õŒnﬂL›l‹<9î˙O §[˛ò∏ô$ôêô¸öhö’õBõØúúâú˜ùdù“û@ûÆüüãü˙†i†ÿ°G°∂¢&¢ñ££v£Ê§V§«•8•©¶¶ã¶˝ßnß‡®R®ƒ©7©©™™è´´u´È¨\¨–≠D≠∏Æ-Æ°ØØã∞ ∞u∞Í±`±÷≤K≤¬≥8≥Æ¥%¥úµµä∂∂y∂∑h∑‡∏Y∏—πJπ¬∫;∫µª.ªßº!ºõΩΩèæ
+æÑæˇøzøı¿p¿Ï¡g¡„¬_¬€√X√‘ƒQƒŒ≈K≈»∆F∆√«A«ø»=»º…:…π 8 ∑À6À∂Ã5ÃµÕ5ÕµŒ6Œ∂œ7œ∏–9–∫—<—æ“?“¡”D”∆‘I‘À’N’—÷U÷ÿ◊\◊‡ÿdÿËŸlŸÒ⁄v⁄˚€Ä‹‹ä››ñﬁﬁ¢ﬂ)ﬂØ‡6‡Ω·D·Ã‚S‚€„c„Î‰s‰¸ÂÑÊÊñÁÁ©Ë2ËºÈFÈ–Í[ÍÂÎpÎ˚ÏÜÌÌúÓ(Ó¥Ô@ÔÃXÂÒrÒˇÚåÛÛßÙ4Ù¬ıPıﬁˆmˆ˚˜ä¯¯®˘8˘«˙W˙Á˚w¸¸ò˝)˝∫˛K˛‹ˇmˇˇ ˜ÑÛ˚endstreamendobj186 0 obj<</Metadata 91 0 R>>endobj91 0 obj<</Length 11047/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.1-c037 46.282696, Mon Apr 02 2007 18:36:42        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+         <dc:format>application/pdf</dc:format>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xap="http://ns.adobe.com/xap/1.0/"
+            xmlns:xapGImg="http://ns.adobe.com/xap/1.0/g/img/">
+         <xap:CreatorTool>Adobe Illustrator CS2</xap:CreatorTool>
+         <xap:CreateDate>2006-05-22T16:29:31-07:00</xap:CreateDate>
+         <xap:ModifyDate>2006-05-22T16:29:36-07:00</xap:ModifyDate>
+         <xap:MetadataDate>2006-05-22T16:29:36-07:00</xap:MetadataDate>
+         <xap:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xapGImg:width>256</xapGImg:width>
+                  <xapGImg:height>64</xapGImg:height>
+                  <xapGImg:format>JPEG</xapGImg:format>
+                  <xapGImg:image>/9j/4AAQSkZJRgABAgEBLAEsAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABABLAAAAAEA&#xA;AQEsAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAQAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9U4qxnzl+YGi+WIeM5+s&#xA;ag4rFZRkcqdmc/sL/mBmHqtbDCN95dzstB2Xk1J22j3/AI5vOF1781POsjfoxXstPJI5wH0IgPeY&#xA;/G58Qp+jNT42p1H07R+X2vQnTaHRj1+qfnuflyCIj/I7X7n97qOsRCY9aCSY/wDBNwyY7Imd5SH3&#xA;tZ9o8UdoQNfAfraf8mfNunEzaPq8fqrv8LS2zn5FeQ+84D2VlhvCX6FHb+DJtkga+ElO38+/mJ5R&#xA;uUtvMlq93anZTPTkQOvp3CVVj/rcsEdbqMBrILH46spdmaTVR4sJ4ZeX6Y/2PU/LPmrRvMdj9b02&#xA;XlxoJoH2kjY9nX9RGxzdafUwyxuLzOs0WTTy4Zj3HoU3y9xHYq7FXYq7FXYq7FXYq7FXYq7FXYq7&#xA;FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWM/mB5yh8saKZ1o+oXFY7KI9OVN3Yfyp/QZh63VDDC/4j&#xA;ydl2XoDqclfwjn+PNgX5ffl9N5gmPmbzMXuIrhzJBBId5z/vyT/I/lXv8uus0OhOU+Jk3v7Xedqd&#xA;qDAPBw7Ecz3eQ8/xzZx5+tvNi6HbxeUh6UscqiWOH00YRBTQJyooAalQP1VzZa2OXgAxOl7MngOU&#xA;nUbiut80ps/Inna9gjuNY813lvcuoaS2tD6YQkfZ5RuqtT2XKIaPNIXPJIHycrJ2lpoEjHhiR3y/&#xA;aFz+TPzA02s2j+apLxlqfq2oKXVh1pzYy/qHzwnS54bwyX/W/BQO0NJk2yYRHzj+A3p/nGHUbg+V&#xA;/O+mJY384Cosg5W09dhwYk8ST9khjv0NdsYaoTPhZo1I/Irl0Bxjx9NPiiP9MPx+AwzzR5b1b8vN&#xA;dg1zQ5GbTXfiOVSFqamCWh+JWA2P8RXNfqMEtLMTh9P42LuNHq8evxHFlHr/AB6g9f8ALmv2WvaP&#xA;b6nZmkcw+KM/aRxsyN7g/wBc3uDMMsBIPJ6vTSwZDCXRMsucZ2KuxV2KuxV2KuxV2KuxV2KuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KvEteWTzr+ai6ZyJ0+ycwPQ7CKDeY/N3qoPyznc3+Eanh/h&#xA;H6Ob2emI0eh4/wCOW/xPL5B6Hb+ftBXzUvlKGCWOeL9zHIFUQhkj5cBvyoFFOn4b5tY62Hi+EAb+&#xA;x0E+zMpwfmCRR38+aXfmP+Y48uhdN01Vm1iZQxLDksKt0JHdj+yv0n3p1+v8L0x+v7nI7J7J/Meu&#xA;e2MfaxO3/Lv8x/MSC+1nVGtjL8aQzyOXFen7pPgj+X4ZhR0Ooy+qcq9/6naT7V0enPDjhddwH38y&#xA;l0X5e/mBp/mq0jg9WUQSIYdTVz6Sx1BYkk/CBvVO/gcqGhzxygDp1ciXamkyYJE0LH09b/HV6p5m&#xA;0zyz5qtp9Elu7d9Rh5NEEkRp4JAPtcAeQH8wObrUY8eYGBI4vtDzGjzZtMRlAPAfLYhJPKFzJ5j8&#xA;vap5T8xfFqOnE2lyx3Zk39KUE9WVl6+wPfMfSy8XHLFk+qO36i5mugNPlhnw/RP1D9IY5+T+oXek&#xA;eZtS8rXhpyLlU7CeA8W4/wCsgr9AzD7LmceSWI/gh2PbuKOXDHPH8A/t+97Fm/eRdiqVeavMVp5b&#xA;8vX2t3al4LKPmYwaF2JCogJ6cnYLioeRD86PzLsbSz8yaz5ct4/KV7IqRyxFhNwapVgTKxqVGxaM&#xA;K3alcFs+EPb4J4riCOeJuUUqq8beKsKg/dhYMG8x+dtZ0780fL3li3WE6bqkDS3JZSZeS+rTi3IA&#xA;f3Y7YEgbM8woSfzh5kg8teWdQ1ydPUSyj5LFWnN2YJGte3J2AxSA8cH5pfnBpunWfnDVtPtpfK17&#xA;IoFsiqrLG5+EghjIvL9lmqPvGC2VB7rZ3cF5ZwXcB5QXMaSxN4o6hlP3HCwebfml57866J5m0XQ/&#xA;K9vbXNzqsbFYp13aQNQAMXjUbeJwFkA35F/MzzRcebG8n+dNLj03WniM1pJCfgkCryK05yqfhVm5&#xA;K9NiKY2pD07CxeMan+Yf5oeYvMesWfkWzhXTtAkaK4eZUaSd0ZloPUI+2UPFVFfE74LZUGb/AJW+&#xA;e385+Wv0hcQLbX9tM1tewpXh6igNyQNUgMrDY9DXEIIpEfmb5k1Hy15H1LW9OEZvLT0PSEylk/eX&#xA;EcTVAK/sue+EqAmnlXUrjVPLGj6nchRc31lbXMwQUXnNErtxBJoKtigppirsVdirsVdirsVdirxr&#xA;8jo/rOv6xqMu8wiAr7zScm/4hmg7IFzlI933vX+0Z4cUIDlf3D9rI/Itjb33nbzVrNzEslzbXptb&#xA;WRgCYxHzjYr4EqqjMrRwEs2SZ5iVB1/aWQw02HGDsY2fPkWM/l3bR+YvzH1TWb4eqbZpJ4Ubejl+&#xA;EW3+QnT6MxNDHxdRKcum/wCp2Paszp9HDHHa6H2b/Mpr5z85+brzzcfK3lYiGWEUkkHDnI/D1G+K&#xA;TZVUfTXLtVqsssvhYnF7P7P08NP4+fcH37b10TD8sfOuuapqF/oOvAPqVgGb1eKq37txHIjhKLVW&#xA;YUIy3s/VznIwn9UWjtjs/FjhHLi+iX6RYYLoeg3OhfmvZabdz+pJHcchcITVw6F1Jr/NWjD55rcO&#xA;E49UIk9Xd6nUjNoZTiOceXx/FM+ZRYfnMnpVC6tpvKYdi6Eiv3QDNp9Or2/ij+PudEDx9nb/AME/&#xA;x97GdZQ2H54WssXw/WZoCQP+LohE/wB++YeUcOtBHUj7qdlpzx9mEHoD9ht7Lm/eQdirAvz2/wDJ&#xA;Va5/0a/9RkOApjzRfl3VvLFj+X/leLX7yytYp9LszDHfyxRq5S3j5cRKQG48hWnSuKll8LQtCjQl&#xA;WhZQYylCpUjbjTalOmFDybzr/wCT88m/8wsn/M/B1ZDk9cwsWBfnt/5KrXP+jX/qMhwFMebEfOP/&#xA;AKzdp3/MLp//ABNMeiRzeqeT/wDlEtE/5gLX/kyuFBeU/nPqd3pf5l+UNQs7GTUrm2jd4rCHl6kr&#xA;cz8K8VkNfkpwFI5IHyhr2peafz0tdS1+0bQr2wspEsNLmSRZWXg44kuiEnjPI9SB02xSeT3vCweJ&#xA;/lB5i8v6R5g88Lqup2mntNqjGIXU8cJcLJNXj6jLWle2AMimH/OODK3l/XWUhlbVHII3BBjTELJP&#xA;/wA9v/JVa5/0a/8AUZDiUR5p/wDl/wD8oH5b/wC2XZf9Q6YVKfYodirsVdirsVdirsVeM/ky507z&#xA;bq+jzHjL6bLv3e2l4kfcxOc/2UeDLKB/FPX9vjxMEMg5X/ugyfyZINN/MDzVo8x4vdyrqFtU7MHJ&#xA;Z6V6/wB6OngczNIeDPkgeu/4+bre0B4mkw5B/COE/j4MF8gR+adP/MEQQ2ksAlmZdSgKH01hqSas&#xA;R0Xqp77eOa3RDLHPQFb7+53faZwZNJZIND0nz/HNm3nX8stR1PXP09oF+LDUnCibkzx/Eq8A6SRh&#xA;mU8RQimbHV9nynPjgeGTpuz+2IY8XhZY8UPgfsKJ8keSIPJsF7q+r3qS3kqH6xcVIjjjB5N8TULF&#xA;iASSMnpNIMAM5ndr7R7ROrMceONRHIdSWJ+Tnl82fmpc+YEQixtC0qlh0UJ6MCnrRj9qnscwdKTn&#xA;1JydB/YHaa8DS6EYv4pfrs/qTvRtZ0/zH+bkl5aPWDTbB4YmYUMjLIVYqPD98cycWWOXVWOUY/j7&#xA;3D1Gnnp9Bwy5znfu2/Ykd4/6W/PGJYiWS1nQVHb6rDyf/h1IzGkePW7dD9wc3GPC7MN/xD/dH9T2&#xA;fOgePdirBPzyjkk/KzXFRSzAW7EDwW6iZj9AFcBTHm8z/MW98pan+S3le4S6gn1jT7e1tLZFlPqx&#xA;t6SJdKYg3jCKll27ddwWQ5vedCVk0PTkcFWW2hDKRQgiMVBGSYPLvPc8EH57+TpZ5FiiS0flI5Cq&#xA;P78bk7YOrIcnq1rqem3blLW7huHUcmWKRXIHSpCk4WLDfzyjeT8rNcVByIFuxA8FuomY/QBgKY82&#xA;CecNX0xv+cddJgW6iaaaGzgjjVgWMkLK0i0HdApr4Y9GQ5vYfKaPH5V0aN1KuljbKynYgiFQQcLA&#xA;vNvzLmhh/OLyNLM6xxIHLyOQqgcz1J2wFkOSHvtT0/V/+cjdBk0ueO8isdOliu5YWDoj+ldEgstR&#xA;t6yA+5pj1Xo9mwsXgf5aeQfKXmrzF50k16w+uPaam6259WaLiHlmLf3TpWvEdcAZkp//AM43RpH5&#xA;d1yNBRE1N1UeAESAdcQiTIPz2/8AJVa5/wBGv/UZDiUR5pn5A1nSB5K8uQG+txONNskMXqpz5+gg&#xA;48a1rXamFSyrFDsVdirsVdirsVdirxXz7Bc+UfzEtfMltGTa3b+uQNgWpwuI/mynl/ss57WxODUD&#xA;IOR3/W9j2ZKOq0hwy+qO3/En8dzLPOFhcahFpfnfyuRcX9iokCKK+vbNUslOtVqw49dz3pmdqoGQ&#xA;jmxbyH2h1egyjGZ6bPtGX2S/H6E60zzNbeavLN3Lok/o6i9vIgiZgJIJ2QhOXsG3DZkY9QM2MmB9&#xA;VfIuHm0Z02YDKLhY9xDybQtE/NjQ7me702yuY5JCUuA/CQOa1qVcnlv+0PvzR4cOqxkmIL1Op1Gg&#xA;zARnKPlz/HwTd/J35qebJUTzBcm0sQwYrKyBR7rBD1YduVPnl50upzn94aj+OgcQa/Q6UXiHFL4/&#xA;ef0PT/K/lfTPLmmLYWCmlec0z7vI52LMR+Azc6fTxxR4YvN6zWT1E+Of9iUazbeVPJVnqPmO2s44&#xA;L+dWVTViZJZDyVFUkhQWFW4gbD2yjLHFpxLIBUi5ennn1ko4TImI+wd/9rE/yV0S5uLzUPM97Vnm&#xA;LQwSN1d3bnM/30FfnmD2TiJJyH8d7tPaHURjGOCPTc/oD1rN48q7FVO6tba7tpbW5iWa3nQxzQuA&#xA;yujCjKwPUEYq8/svyD/Li01VdQW0mlCOJI7OWZngUg1Hwn4mA8GY4KZcReiYWLEvOP5XeVPN19Be&#xA;6zHM89vF6MZilMY4ci24A8WwUkF3k78rvKnlG+nvdGjmSe4i9GQyymQcOQbYEeK40pLKLy0tb20m&#xA;tLqJZra4Rop4XFVdHFGUjwIOFDzqw/5x9/Luz1ddREVzOkbh47CaUPbgjcAjiJGA8Gc174KZcRel&#xA;AU2GFixTzl+Wflbzfc29zrMczy2qGOIxSGMcWPI1oPHGkgq3k/8ALnyl5R9V9Gs/TuJxxlupWaSU&#xA;rWvHk32V9lpXvjSkslxQkflvyZonl251O501ZFl1ab6xeGRy4MlWb4a9BVzikl3lPyZonlW2ubbS&#xA;VkWK7mNxMJHLn1GAU0r0FBipKJ8y+XdN8x6Jc6Nqau1ldcPVEbcG/dyLItGH+UgxQGG2H5Cfl7Y3&#xA;1ve28NyJ7WVJoiZ2I5xsGWop4jBSeIvRcKHYq7FXYq7FXYq7FUo81+WbLzHo0um3XwlvjgmAqY5R&#xA;9lx+ojwyjU6eOWHCXL0Wslp8gnH4+YeS+W/NGu/l5q0mh65A76azcqLU8QSR6sBNAyt3H6jXNHg1&#xA;E9LLgmPT+Nw9Vq9Hi1+MZcR9f42kzO58oeXvMcg8xeU9UOnai+7XNofgZjuRLFVWVj+109wc2EtL&#xA;jy/vMUuGXeP0h08Nfl048HPDjh3S/QXI35y6fSLhpurqD/fEmNyPehgH4Yj83Hb0y/HwUjs6e/rh&#xA;+PigtZ0b83PMenvaXklhpsBozRQvIrSEdFLKZtvpyvLi1WWNHhiPx727T6jQaefFHjmfOtvuT221&#xA;mz8leVLO28x6is9/BGaqrGSWQliVVFajEKCF5Gg27ZkxyjT4gMkrkHCnp5azPI4Y1En4D3/e84A8&#xA;xfmh5iBINpo1ofmkKHrvtzlen+YzU/vNZk7oD7P2vQfuezcP87JL7f1APbNN06z02wgsLOMR21sg&#xA;SJB4DufEnqTnQ48YhERHIPG5ssskzOW5KJybW7FXYq7FXYq7FWK/mj5gv/L/AJE1XVdPdI76FEW3&#xA;d6bNLIsZYBtiyqxKjxxKQkH5PRareW0muP5kv9W064iWD6lqMXB47lQrSOrF3+Hcgcdt+ppgCSmG&#xA;qatqU35v6JottdSR2Nrptxf39sjERyeoTBH6g6Hi1CMUdGbyOEjdyQAoLEseI2Fdz2woeJflVrHm&#xA;XzfrY1ObzPfRXdrO8+oaT6IbT2tywVIYnDcK+9K/SORAZHZm/wCa2t6xZabpWlaLcmz1LX9Rh09L&#xA;tRVoopK+pIvuNvv8cSgJn5P8r69oUt6NQ8w3Gt2s/D6rHdqDJCVHxH1OR5cielNqDCpLEfzHs9dm&#xA;8/8AlvTdN8w6hYLrrTLPbW0vCOKK0jDs6AD7TVO5wFIZl5jupfLvkLUJxcyT3Gm6dII7uZqyySxw&#xA;lUd2/nd6E++FDyr8pfMPmXVPN2lxW2t6jqtmti83mWK+H7mGV0PpLCzfETzK9twCakdAGRZ7+aus&#xA;61bWmjaNol2bHUdf1CKy+uKvJ4oCCZZE912+jEsQgPyym16Dzf5u0S71i51nTtJe0W2uLw8pBJLG&#xA;zOob2pQj2rtiElLvzO8+6noH5i+XIIJ5E0q2jFzrUSH92YLmYW3OUdDw6rXoT74lQNmQ/lHqupaz&#xA;oWpaxe3Mlyl9ql29jzYssdsrBUjTsFBVqUxCCt8satqep/md5tjN1I2k6THaWlvalj6XrSJzkcL0&#xA;5AoRip5ITzrda/rPn7S/J2l6rPpFqLKTU9TubSgnKCT0o1Dn7PxD8d67YpDLfKmkavpOjpY6rqr6&#xA;zdRuxF7KgRyhPwq27VKjuThQXlGq655mu/zQvNI1LzLd+V2+sRR+XrcQcrO5i5U+I8lDNJ25bcjx&#xA;r0XAno9vwsUs1/y3o2vWZtNTt1mQbxv0dD4o43H+dcpzYIZRUg5Om1eTBLigaeYah+UHmfR7s3nl&#xA;bUi9PsqZDbzgdePIURx86fLNNPsvJjN4pfoL0uLt3Bljw54/ZY/WPtWJrP54WB9KW1mueOwJgim/&#xA;4eIb/fiMutjsQT8B+hJ0/Zk9wQPiR9617z88dWrEsU9qjGhokNrT/Ztxf7jgMtbPbcfIJGPszFvY&#xA;l85fsRuifkreXFz9d8z6gZnY8pIIWZ3c/wCXM+/zoPpyzF2SSbyH8e9p1HtDGMeHBGvM/oD1HTtN&#xA;sNNs47OwgS2toxRIkFB8z4k9yc3OPHGAqIoPM5c08kuKZslE5NrdirsVdirsVdirsVYt+Y/kuXzd&#xA;5fXTYLwWVxBcR3cErIJULxcgFdD1U8sSkFGeUtE1/S7Sf9N60+s3lzJ6pcxJDFEKU9OJFrRfp+gb&#xA;4qWOa15B83y+drzzPonmCHTpLq2js1iltBcFYk4sVqzU3kXl0wUtstvtIn1Dy1caPeXRae7sntLi&#xA;9RQpLyxGN5VQbDc8gMKGL/l/5C8z+W3hj1HzGb7TbKFrez02GBIYuJbkJJDuzMPv/wAo4Ekov8wf&#xA;JWqeYpNIvtI1JdM1XRZ2ntZZIhKjFwAQwP8Aq+BxKgpx5W0jWNL01odX1eTWb2SVpZLqSNYlXnT9&#xA;3Gi14oO2/wDTCpQd35SkufP1j5okuV9GwsZLSGz4Hl6srktJzrSnA0pTFbVfPnlq58zeVL7Q7e6W&#xA;ze9Eam4ZDIFVJFdhxBX7QWnXFQUHo3kb9E+dr7zBbXK/U72xgs2suHxB7YIiSGStD8CUpTAtqP5g&#xA;eSNW8w3Wjalo+prpuqaJLJLbPJEJo29YKG5Ke44bbHqcSoKJ8heS5fLNpfNeX7anq2qXDXeoXzII&#xA;w8hFAFQE0A/z8MKkpfrn5Zx6zrXmHULy7Vo9Z01NMtovTJNvxIfnUt8X71Q9KDBS2nnkjyyvljyr&#xA;p+hLMJ/qSMGmC8AzO7SMeNTT4nPfCpKH8neUZNAuNcup7kXVzrWoS3zMqcAiPThFuWrw33xUlJfM&#xA;35e+ZLzzi3mTy/r40ia5sxYXYe3WdhEG5ExciADsNttxWuClBZppVnPZabbWk91JfTQRqkl3NT1J&#xA;WUULNxAFThQ8+f8AKvzJqPmCwuvMPmZtU0nSbs31jbNbpHOXLBwkki0+EFR0HToF7CmVv//Z</xapGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xap:Thumbnails>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xapMM="http://ns.adobe.com/xap/1.0/mm/">
+         <xapMM:DocumentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</xapMM:DocumentID>
+         <xapMM:InstanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</xapMM:InstanceID>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="r"?>endstreamendobj149 0 obj<</BaseFont/SZKDGN+MyriadPro-Regular/Encoding 147 0 R/FirstChar 27/FontDescriptor 148 0 R/LastChar 151/Subtype/Type1/ToUnicode 88 0 R/Type/Font/Widths[307 284 284 523 523 212 0 0 0 0 0 0 0 0 0 0 0 207 307 207 343 0 0 0 0 0 0 0 0 0 513 207 0 0 0 0 406 0 612 542 580 666 492 487 646 652 239 0 542 472 804 658 689 532 0 538 493 497 647 558 846 571 541 553 0 0 0 0 0 0 482 569 448 564 501 292 559 555 234 243 469 236 834 555 549 569 563 327 396 331 551 481 736 463 471 428 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 207 354 354 0 0 1000]>>endobj147 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[27/hyphen.cap/parenright.cap/parenleft.cap/f_l/f_i]/Type/Encoding>>endobj148 0 obj<</Ascent 952/CapHeight 674/Descent -250/Flags 32/FontBBox[-157 -250 1126 952]/FontFamily(Myriad Pro)/FontFile3 87 0 R/FontName/SZKDGN+MyriadPro-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 88/Type/FontDescriptor/XHeight 484>>endobj88 0 obj<</Filter/FlateDecode/Length 535>>stream
+Hâ\îÕéõ0Ö˜<Öó3ãÏ{	EJìéîE‘LÄÄì"5ÄY‰ÌÎ„É&£"Åè¡ˆ˘|‡ín˜ª}ﬂÕ&˝9Õ¡œÊ‘ıÌ‰Ø√mjº9˙s◊'´‹¥]3/Ωxm.ıò§aÚ·~ù˝eﬂüÜ§™L˙+<ºŒ”›<m⁄·ËüìÙ«‘˙©ÎœÊÈ˜ˆl“√mˇ˙ãÔgìôı⁄¥˛˙VèﬂÎã7iúˆ≤o√ÛnæøÑ9èÔ˜—õ<ˆWÑiÜ÷_«∫ÒS›ü}Re·XõÍ-Îƒ˜ÌœE9Ìxj˛‘SR≠æÑ¡YñÔ÷Ao©KËı+Ù◊®E¬πEˇÌ—«ÿ<„ÿzY„Ú›cÌúkÑ&hŒMRe‘÷)6‘hé)0∆Æ¢M–9ΩsËÇ˜hKm°µÉjÅVjÖ~•∆˛,,,ÛM–‹ã≈^,˜b±ÀΩXÏ≈í”Ç”1á989898989úéúúéú
+NGNN«¨≤Ê#»G>Â#Ù¯
+}æB_ÅØ»Ú.°È+˙
+|ÖæÒ]}%˙2+AV¬¨‚˜!ÃJêï,ﬂ≤íÂªAV ¨Y)˘¸J~øí_¡Ø‰W+˘¸˙)7%øÇ_?Â¶‰W+˘¸%ºÚlÖ˚eA˛“RÉøTjãi©îU®~ÛQ≥ÕmöBπ∆_D¨STh◊˚èø»8å&Ã¬ô¸` 8ãÈendstreamendobj87 0 obj<</Filter/FlateDecode/Length 4804/Subtype/Type1C>>stream
+Hâ|TyTSWèG^¬‚CHü%…ò¡Í0EîEDGP,Óä⁄∫I Q÷à‡T±ä ´À°≈Qd±¢ÄJ±"Udd\(»R•£VÎ˜‚≈„º‡å3ÕπÁ‹wøﬂ˝ñﬂ∑‹ác∆Fé„¢Ä/W{-˜˘|MºF-W¯i"g˘+Cc√‰√%√ p÷⁄òùfN#Gî˘ˆÌ[o‘Y¿êÂè¯ƒŒ
+„„∏ôhÜù}Û}U|îJ·,èäíkîu®J˚Q
+SÜL!€¬B∂©øàåäü∏ó9Õô3«ﬁ∞ª»&>s=ë€ï≤Ä¯≠2<F∂2"8R©ëkï
+ôgXòÃﬂ`#ÛW∆(5qpΩCÄÉÃèSà– º\Ê∫ÿœusr¯êäL#ìÀ4 P5ÁM£T»¥πB.◊ÏîEÜ»˛O§ŸÀ÷≈G)en2Ö2√pnaõD`bìaòç ≥ÁaŒlâScò√ax≤1Ê≈’[É˘aXñè’a=¯<g¥¬Ë*aB)D±±©±≥ÒJ„Ω∆Ÿ<Sﬁfﬁyí C…ü»ü˘÷|˛èÇOkZ¡ê…:ìlSc”ç¶9füôÌ0À7{inoæ»º⁄¸˝$œIÁ(L’Ro-ñZÏµx:y—‰‹…mñ§ÂKÀÌñG-oXôZyØK´c«Ípnü^G§≥)zøÒ2Q#ç<‡FI$C◊h0„G˘„‰÷â3x N&Ÿz⁄pBâBœ(Ωá/É?£z:—+⁄6vm√Î≥µó +x$†>è√Û¿ëËC&ÙŸÀ’@Ù€Ì≥N\%ãÛP(æi∆K ç(Åz§5Û©D∞¬Î¡å "ëÆ,8SQS§Ri¢CB£ 
+©Ùû:<û-¡4ú”´yÀIT˙NÕ£‰˚Ó¡Çªpı.^5 9Oàg˚ËS©g”K∑k+©ª*∏s˚ s∞√Ç˘Ä!9!Y ‚û3ò4◊UWH3…Ωa˛Aä’WqÑßƒ⁄ï! ∂ò©rEƒ◊)˚Óg⁄-~íE_ﬁx0r≠•õ·ÿZ¬Æèå·©År9Sô™=£í®4Q!*ÎtÙ˚Gº»ÄG¿)d«Ÿ≥)ùV`fvÔ1üDÏ=Êíà	GÖΩ	ÎË‘”)?Ø©Æ]i8_◊*ÓŸ–Å¯Åªc‘“Boﬁ…”æ´ê4•ñ™7ä∑j[◊K7˘≈˚	Ãà∂éV¢mAˇSøoúäU+¥˜¶È¨N≥∑ÑΩÏBP—ùH≈„öû†wÂŸê(˛ù+oàlÔD+›x¬—øV}[ï}AêAf+≤És∑µ†@kjOR+‰¥@Ã]´ûà\1"|›ìA'◊&ﬂîÄQO˛•ÀLŸπÇÍFÒÛ≈◊VófÖlG—•Õ‚kqTE“2y@Æãƒ«7iøí£3s
+2/HoÜ-\µ˛´ŸÃBr•q')|˝¥O9€Œmácò&=3Å°N'v≥µ]·:´äa[4L'®÷'Jêõ˝Ô0ñæ~Nó˜Ó>«+OuÑmﬂiOÃì %≤ÂV(ä[4	¸ﬁ…;^ P@$µ≥ó⁄û÷lò‡∏¨ÆOπ-ÅO_ï551M∑ÀÜ¿H∏ÍæÔuÈu?ßbd)YÊù¥?êXM.(À™ëÄ˜–‰ú †U3lëèzgzV¨îÚNÎÇ‰NPwqé	÷ùµ¶Q.®°§k{Á Zt°HÜ\íZŒµ¢±¥z=S†éu¢c†Ö‚.Ùû§ÜtBd;Ì
+3§Àö˜«ÿü·ç4Ka*⁄BÓ”)ˆ˚Kê„Ù∞‹ﬂº∑÷ö=ª+·CÍc9>yÓá§h&⁄í ÿT86HΩ[Gøî˜‰|œPcÉ∂(◊q†oêË—ª“Ô\†˙P€†ﬁ’ï£>(ÁS®ÌTúﬁU7AÙÉéﬁïOÌ˘/»±œ&ÔtÉ=Ê˝F¢„¨5§¿˜<Ñëh;:í-JÅ˚.$Âñ÷≈˛˙o+÷¨U±ør(ddÅ…Ã8ˆÒÄU£ﬁK•∑õ“O πyDâÃQOXÓ„ô∞\êB&¥kª#!>ÙYs∑¬®Õ‹º>"O¿≈#//„±(É<˘Á3.•ˆa%‡®õ◊BrÔÎe#g˚˙DôdÍº#àwxñÄ˙-Há8ˆŒÓ1Ù<ÑßÖõ¡i
+TÒÖa`|Ë¡¡~ifzŸíèÀãE∞=Âq%ôè IaûM∆¸cé“C©;€õ˙D(~·ŸøsÂ“'v∞?t‡£Ï#º‘{“h˜∑ë°(,ëñ¡bòÿåÃ`ÚfíΩh¯¨ùS£YÓH»ık™;–0˛ÿ	"òŒPZÆMyÌPlòTH˙PÌÚ`~ajë§ˇﬁÈ´µLY˘â+∑ƒ7cØÜîJ+ÇΩÛÁJñÆK: gºÈ¨‹‚ÃÛígMAN´7⁄Dƒdﬁ≈P	ú«ö8z˜<÷<$˚R*T˘'ÁÂ˙´ë_Ìné˝ew{ÿï'ô¸é¬ÜüûàÎw’™K§ÁÂæy_ÔÉﬂlc|Ë¨úí¨ãíë‘&•ãÿ√o£É‘â§÷$v±W:wË¨!¸â∞˜‚9:¶¢C◊,Áﬁ·Wˇ\{ë’åC≈ˆø7âkÀØè‹™—Ì˝õTXS»Õno^¯¶„À$ËSw˚V0R0√™äPoÒÚõù|˝ÛRjÌ©8v¨á†AÇ¶≤c∞Ω{<Ÿ‰$5¬ı‡≠ø7›Éƒ=n^«ßÒëÚ’Bê¬¿˚!X Nu∑Â#ª’+g:Æ¯ÕU‘DûÖ'ªÓljóÆ0ôÙV˜(•‡≠Í(85
+Ç®∞8ÂrT@ÂhúUH¿uêp*(√‚»oEπ5:*(<@á]kÊ5ıc´ˆ,ˇÌ™˜Ω˜˚æ˜Ω˜∫ñ0ºùHúì˝jì•°mr˘ÎT,òl·ÓøÂ$"ëŸ“~NáW+›≠¥‰ëgÒœΩû#“e$ƒ‚ﬁÉ1{ U¡˜˝˜Q—tµŒ€æÉµøb¥®«–ãÁfﬁÊBÔ2óÙA˙öÑ åÎH:¢qÇ*P¨Qz®=1l∆É#É ¡Ø·≠t%π
+ç':+\9Ø/µdz˜ë·‰aWòêÆ aÉ%]ÒGﬂU•BæŸ}Ô!Ü{rråMâQF|©!è‘*´„çé‡(]HÇô±'à_…!p®πs∫ˆt=6IYd˘˜5˛f¥H*VÑf≥◊D†‡ø »≈»/nW‚Â\à¢5π1Æc)¯IH80#%PΩH¨≈nÆ0	ŒÛúº-œôf˛îCÚV|qm&x#º’àfÊŒ	ÒFÆ;JŸù Ó∂©É∞™ç_Ìí…}S»¡oGJ\sfQ^›ZÿBøœˇ&ÇÕ°m:;d-˚∂}”/˝W´Î*ÒÇ¶T'˝àAÚÿ%mcìlu´Ñj;™Õ–e¬’æÙÓΩï∑&@PÚNÀäπÅΩ
+ﬁ} ¢ìmL£P;Fµô‡/J™ïk£òüI™-wê»!}jo∆–Ã‡…ÇΩnıØËs⁄=``´Ö[Œ‰Ëåß§0«†?≈ÙñﬁlºKO¥Ø]åÑÛX·≥´©3Ö’û“ÊÁÀƒ_·ñ˚l@P˜R»€K∏¯®¥ z…7˝0gÍÓs^πƒ•ó±g˙CBH¡w4r\ÄoèE»·≠=,ÏÓ(1úe≈y‹ÉHøæﬂRo›K®¬ıÚˆ”r	j“äÍìÇj<i4◊ﬁπËXdˇ ¨ü›iº^…Ë1#πkàg§ÊRV[≥å.rö…ï®≥“5È’Êùπù^<ÙÀÔ◊_˜\		(`s8ùäìâπ~pªv˜u√ê?"‰√A!—ÂÈKe/√ÄEéhû°Öh·KXÙ‰ZI·FuüPGÌÂ|ißmG-´ª/È<Yˇ¸%˝˛ús@>fp_Ú.Ω∞ÓÅ‡˘®‹my∞ÓE÷?âùÓy\Qz¸XcË#N¶ƒûå°√˜§EG±·ë™≠õeâõΩ˙f\D‚\¥∑Ê˜¬t?7KB≈(ﬁx)AB›—◊Îkòı$5ôπë–íä#^Î¬Øñ£µHf^ ü?æZ€R…ÍI$ˆ˛˚™mA•g¢ô$/"ÆæK}õÓÏ+4∂≤≠MÂ} î9√_%*m q†îƒ¸<{sÓ>Ój€UÃÊ¶Î“T2q6~À:VC`nLh≤É≤DWp¬¿\)ni∏Eø®Úvg—Ö1º.¿’ÆaKTLÜ*éâU%%©„≠¥p√â£GEô¸ÿ‹¡¢1j\ly•”åRDMß◊H¢bñ'\®)?w>ãΩ†8≈àQ7⁄◊?MŒFô>FÌC˚$≠]≈ııl≥±®sB∆ouöY"BVG#bE‚~.BcEM¡∆È€í(åx®,˛RMYE’,b4#vô≠≤[∞.Œ∏´úˇ'Ö-dK;∏"Ò;â@lÉ`bâÊ#WuJä"=[^å‚¡ ∑ê`a`Zé1úÎC,ë…Õc¶ÜL∂fÃNëæËDc,l0ﬁ†{´÷≥®ŸWE≈9≈π¶π®˛r;˝†:`9ã*ÕP'∑•M>!—ÈIáòdïR°ä≈3ñ"®¡õv›Àj∞E3üÎ…ú]x–'E,i-ÇPO,ä-9sÛô∂¢ñ∆€Xë-Xëãc–$Çuv^ÆªC-Iµ$‹?·„z¯π=ÿ™–˙J¯$H6o)ZçñM-Å/¿˛¸6É√≤)ƒ≤Zo…áFªØë¿◊mçãﬂ‡ooZﬁ}¿≥}´Äm˝ºpÄ˚4\&MH.Öb=\uÛp‰ofÿˆNÔëµõˇ˛Ì˚X\∆PÊ¬ç‘áËÉ∂ FC$ÜúÇú|ÜöÏ)πŸ|óÔ∞Ãï¿À}w6u¶≤⁄|≠°@&˛q6’ ˇáÓ”\ò‰ÌqÆ1˛ﬂ∞]◊§od÷b[h,∂hM∫ÏA/@÷Æ»ŸøYƒ”ÎuW~bı$àÁ§iR2”ød˘~zq»;‹xÚ∫ß5$pv(®”eb§ƒØ|¡%ˇÀÚ,™”ÑØÇ|Ãp°ﬁ¿Ùå≠˜hC^ñ6è•
+^à®N˝ˇ–e–€wÜoIb3I™JÛ÷¢’nù‹#9}$˘⁄0»FÑıg%…’mÍk4àz:GÜ6≠π»˙û;T⁄ ´≠:µ•&5˝4SﬁE«Ü i;_˜ç¡£1lwBEbò,‚`¥œûê“í8ÏåDŒ–+7«˘â£á◊cT"Úœ≠àc .©ÈÍ û,a3{àÃ4µ6ÅñßTﬂe°lzëXâƒôú)‹bõÅ1PçQ-|<Øî8°v2Uìz<çâLﬂNªæ˜ÜÖ2'T+BÎ_á˝lÓË®?kô¥ nƒSRSóelóâ=≥«ºf°
+¯›Tl∆ﬂ%1LÇ?Ø$VêÀPæR˜®#∏|≤f4§5§óBÖTﬁŸ√pgü
+•”‘ÂRKËB:H>Ö¸ÀRrµ®›püˇ¬‡í¿G(U:H¬JåÍLnBô©˛iª~ê„œµ©;é‹ˆÄ„RO“e•ÓL˝é≥|?⁄û÷ÆæÓYRÒ
+|Êe'√©d¡è¸6a±%”ZîÅ<P61âˇÔ•U%ˇ◊Ïï¿ñ¿úºŸÛÚ/˝fîxœˆ€Ó{∞/U«™√ÊÆR]X]Tù4µzYÕí enü%¯Ãï˝‰.gúÚ#öy
+»H˜?A¨˝Ω-mRm-ÌMrÂqπô≈Ö•yµ•-%ˆoõµm„Ò˝€ú˙nı]‚˚[	=6ÌﬂÍ3”öÚÄeLÛä˙ç´øoí‡˚-‹}Ò˚ÎKås»2œ˚!{Ò˜˙^∂ÖKÊ/ûøÏ{Œ˜µ=áXˇ∞∫|ü’…VZX^RV¯;ˇ˜F†ÆÿüNÂåkøÔc˛.¯#Nt⁄Â•ünï»èM¯ÕPbŒÒΩy*B∞ 6˛7C©9HóH◊^Ê?ÌD\
+îÀOîX∂s€wÜE˜8é6≈
+ïKë≈¯~~/9Œ∏ÚóÛ ÔD˝9vçzæü=√∏Ú{7Û |¢^ﬂªœ ≈[˛<Ã¯]Ì
+ÛcK—”Œ}˛!ı=“„ªà˜]9w∂Àã¸vó˙ÌÚ[ÃEC™˛ÙUÊÔ·?E}Ã=~ãt˝é‰¯~˛∑»)πl.ÔCæã|wì˙Óy‡ªÿï∑r|Ÿê™÷ˆ<∞™˝´mYœ˝f]Ã~sÂπÁkµ5œí˚+ÚËß+˚¸Ù∞È¡“ëUŸ©Úq…%˛Re–
+7©¬Fòˆ«Ù—èäﬂk≥ﬂXvÊ≈∂çu5‰ñúcù[63N˙∑åÉ≈o˘B®	”~öMˇ7Ìª˛¥=”˛îLb˚·5Ò∑œƒ?˘”vL\1ë]nAÇk”Ãˇ<úÁ∏s?ÓÁ·˝û,Úcø(@Ä ≠	˚^endstreamendobj138 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj100 0 obj<</DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 650.07 269.52 668.79]/Subtype/Widget/T(Name_Last)/TU(LAST)/Type/Annot>>endobj118 0 obj<</AP<</N 63 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.24 650.07 578.88 668.79]/Subtype/Widget/T(Address_1)/TU(STREET)/Type/Annot>>endobj101 0 obj<</DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 625.95 269.52 640.59]/Subtype/Widget/T(Name_First)/TU(FIRST)/Type/Annot>>endobj119 0 obj<</AP<</N 64 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.24 626.43 578.88 640.59]/Subtype/Widget/T(Address_2)/TU([1])/Type/Annot>>endobj102 0 obj<</AP<</N 23 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[26.8802 601.95 173.52 616.35]/Subtype/Widget/T(Name_Middle)/TU(MIDDLE)/Type/Annot>>endobj103 0 obj<</AP<</N 24 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[183.6 601.95 221.52 620.67]/Subtype/Widget/T(Name_Suffix)/TU(SUFFIx)/Type/Annot>>endobj104 0 obj<</AP<</N 25 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[231.6 601.95 269.52 620.67]/Subtype/Widget/T(Name_Prefix)/TU(PREFIx)/Type/Annot>>endobj120 0 obj<</AP<</N 65 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 601.95 452.88 620.67]/Subtype/Widget/T(City)/TU([2])/Type/Annot>>endobj121 0 obj<</AP<</N 66 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/Ff 4194304/MaxLen 2/P 22 0 R/Rect[462.6 602.19 482.88 620.91]/Subtype/Widget/T(STATE)/TU(STATE)/Type/Annot>>endobj122 0 obj<</AA<</F 164 0 R/K 165 0 R>>/AP<</N 67 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[491.28 602.19 578.88 620.91]/Subtype/Widget/T(ZIP)/TU(ZIP)/Type/Annot>>endobj105 0 obj<</AA<</F 158 0 R/K 159 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/MK<<>>/P 22 0 R/Rect[26.8802 529.83 143.16 548.55]/Subtype/Widget/T(Telephone_Home)/TU(HOME)/Type/Annot>>endobj106 0 obj<</AA<</F 160 0 R/K 161 0 R>>/AP<</N 26 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[153.24 529.83 269.52 548.55]/Subtype/Widget/T(Telephone_Work)/TU(WORK)/Type/Annot>>endobj123 0 obj<</AA<</F 166 0 R/K 167 0 R>>/AP<</N 68 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 529.83 578.76 548.55]/Subtype/Widget/T(Emergency_Phone)/TU(PHONE)/Type/Annot>>endobj124 0 obj<</AP<</N 69 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[336.12 505.59 452.4 520.47]/Subtype/Widget/T(Emergency_Contact)/TU(NAME)/Type/Annot>>endobj125 0 obj<</AP<</N 70 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[462.48 505.59 578.76 524.31]/Subtype/Widget/T(Emergency_Relationship)/TU(RELATIONSHIP)/Type/Annot>>endobj107 0 obj<</AA<</F 162 0 R/K 163 0 R>>/AP<</N 27 0 R>>/DA(/Helv 10 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[26.8802 432.99 269.52 451.71]/Subtype/Widget/T(SSN)/TU(SOCIAL SECURITY NO. \(MANDATORY)/Type/Annot>>endobj128 0 obj<</AA<</F 168 0 R/K 169 0 R>>/AP<</N 77 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[433.32 436.95 503.88 455.67]/Subtype/Widget/T(Birthdate)/TU(MONTH/DAY/YEAR)/Type/Annot>>endobj126 0 obj<</AP<</D<</MALE 72 0 R/Off 73 0 R>>/N<</MALE 71 0 R>>>>/AS/Off/BS<</W 0>>/F 4/MK<</CA(l)>>/P 22 0 R/Parent 7 0 R/Rect[336.12 439.95 343.2 447.03]/Subtype/Widget/Type/Annot>>endobj127 0 obj<</AP<</D<</FEMALE 75 0 R/Off 76 0 R>>/N<</FEMALE 74 0 R>>>>/AS/Off/BS<</W 0>>/F 4/MK<</CA(l)>>/P 22 0 R/Parent 7 0 R/Rect[336.12 427.83 343.2 434.79]/Subtype/Widget/Type/Annot>>endobj108 0 obj<</AP<</D<</Off 30 0 R/On 31 0 R>>/N<</Off 28 0 R/On 29 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 388.59 33.4802 395.91]/Subtype/Widget/T(HIGH SCHOOL DIPLOMA)/TU(HIGH SCHOOL DIPLOMA)/Type/Annot>>endobj109 0 obj<</AP<</D<</Off 34 0 R/On 35 0 R>>/N<</Off 32 0 R/On 33 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 376.47 33.4802 383.79]/Subtype/Widget/T(TRADE CERTIFICATE)/TU(TRADE CERTIFICATE)/Type/Annot>>endobj110 0 obj<</AP<</D<</Off 38 0 R/On 39 0 R>>/N<</Off 36 0 R/On 37 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 364.35 33.4802 371.55]/Subtype/Widget/T(COLLEGE NO DEGREE)/TU(COLLEGE -NO DEGREE)/Type/Annot>>endobj113 0 obj<</AP<</D<</Off 50 0 R/On 51 0 R>>/N<</Off 48 0 R/On 49 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 352.11 69.4802 359.43]/Subtype/Widget/T(ASSOCIATES DEGREE)/TU(ASSOCIATEêS DEGREE)/Type/Annot>>endobj114 0 obj<</AP<</D<</Off 53 0 R/On 54 0 R>>/N<</On 52 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 339.87 69.4802 347.19]/Subtype/Widget/T(BACHELORS DEGREE)/TU(bACHELORêS DEGREE)/Type/Annot>>endobj129 0 obj<</AP<</N 78 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Sig/P 22 0 R/Rect[335.353 332.67 575.797 351.39]/Subtype/Widget/T(EMPLOYEE SIGNATURE)/TU(EMPLOYEE SIGNATURE)/Type/Annot>>endobj116 0 obj<</AP<</D<</Off 57 0 R/On 58 0 R>>/N<</Off 55 0 R/On 56 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 327.75 69.4802 335.07]/Subtype/Widget/T(MASTERS DEGREE)/TU(MASTERêS DEGREE)/Type/Annot>>endobj117 0 obj<</AP<</D<</Off 61 0 R/On 62 0 R>>/N<</Off 59 0 R/On 60 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[62.1602 315.63 69.4802 322.83]/Subtype/Widget/T(PROFESSIONAL DEGREE)/TU(PROFESSIONAL DEGREE)/Type/Annot>>endobj111 0 obj<</AP<</D<</Off 42 0 R/On 43 0 R>>/N<</Off 40 0 R/On 41 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 303.39 33.4802 310.71]/Subtype/Widget/T(PHD)/TU(PH.D)/Type/Annot>>endobj112 0 obj<</AP<</D<</Off 46 0 R/On 47 0 R>>/N<</Off 44 0 R/On 45 0 R>>>>/AS/Off/DA(/ZaDb 0 Tf 0 g)/F 4/FT/Btn/MK<</CA(n)>>/P 22 0 R/Rect[26.1602 291.27 33.4802 298.59]/Subtype/Widget/T(OTHER DOCTORATE)/TU(OTHER DOCTORATE)/Type/Annot>>endobj44 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj45 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj46 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj47 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj40 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj41 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj42 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj43 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj59 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj60 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.04 re
+f
+endstreamendobj61 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 39/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏  û}Ûendstreamendobj62 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 61/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏@®¬Pœ¿BLòÍö	à
+Ä   +∂endstreamendobj55 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj56 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj57 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj58 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj156 0 obj<</BaseFont/Helvetica/Name/Helv/Subtype/Type1/Type/Font>>endobj157 0 obj<</Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 160/Euro 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]/Type/Encoding>>endobj78 0 obj<</BBox[0 0 157.56 18.72]/FormType 1/Length 12/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC
+EMC
+endstreamendobj52 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/FormType 1/Length 80/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</Font<</ZaDb 115 0 R>>/ProcSet[/PDF/Text]>>/Subtype/Form/Type/XObject>>stream
+q
+1 1 5.32 5.32 re
+W
+n
+BT
+/ZaDb 4 Tf
+2.138 2.306 Td
+3.852 TL
+0 0 Td
+(n) Tj
+ET
+Q
+endstreamendobj115 0 obj<</BaseFont/ZapfDingbats/Name/ZaDb/Subtype/Type1/Type/Font>>endobj53 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/FormType 1/Length 30/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0.749023 g
+0 0 7.32 7.32 re
+f
+endstreamendobj54 0 obj<</BBox[0.0 0.0 7.31999 7.32001]/Filter/FlateDecode/FormType 1/Length 107/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</Font<</ZaDb 115 0 R>>/ProcSet[/PDF/Text]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ2P0P0◊36ÇE©\i\Ö\Ü
+Ü
+¶ æ)T0ú+®2ùÀ)ÑK?*—%I¡D!$çÀHœ–ÿB¡Hœÿ¿L!$ÖÀXœ¬‘H!ƒl&êØëß©í≈Â¬»` 5@Üendstreamendobj48 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj49 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj50 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj51 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj36 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj37 0 obj<</BBox[0 0 7.32001 7.2]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.04 re
+f
+endstreamendobj38 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 39/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏  û}Ûendstreamendobj39 0 obj<</BBox[0 0 7.32001 7.2]/Filter/FlateDecode/FormType 1/Length 61/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g"ÃçäRπ“∏@®¬Pœ¿BLòÍö	à
+Ä   +∂endstreamendobj32 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj33 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj34 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj35 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj28 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 0/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+endstreamendobj29 0 obj<</BBox[0 0 7.32001 7.32001]/FormType 1/Length 34/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+0 0 0 rg
+1.08 1.08 5.16 5.16 re
+f
+endstreamendobj30 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 36/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏  ûìˆendstreamendobj31 0 obj<</BBox[0 0 7.32001 7.32001]/Filter/FlateDecode/FormType 1/Length 56/Matrix[1 0 0 1 0 0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–3U0Ä‚¢t.=#0a¶g%äRπ“∏@®¬Pœ¿BLòÍöA∞
+Ä   Ωºendstreamendobj7 0 obj<</DA(/ZaDb 0 Tf 0 g)/FT/Btn/Ff 49152/Kids[126 0 R 127 0 R]/T(Sex)/TU(SEx)>>endobj74 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter/FlateDecode/FormType 1/Length 78/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ*‰2T0 BCc=S ab°êúÀe®gnÖ1Ù,Õ°$TL%sÈ"	Í"©Ö≤A* rPaTY]®)»¢» ·Ü§qr ó=âendstreamendobj75 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter[/FlateDecode]/FormType 1/Length 130/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+HâtèK
+Ä0D˜9E.êí‘˙È1<É†+ﬁclâ)§aÊ1L4Õ•j¯†ãå’üÒê∆‚£,ºù‘~e,ñjŒòp:HD	¨ s¢{êøÆ %™CvZIˇ€öﬂ”⁄ˆ%’…0·¥œªQãΩﬂÛxêøÆ %™Cû∂∑  *-Bendstreamendobj76 0 obj<</BBox[0.0 0.0 7.08002 6.96001]/Filter/FlateDecode/FormType 1/Length 88/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ*‰2T0 BCc=S ab°êúÀ¶†C=K##(	ïÅ(‰“E‘ER´UTëÉ
+£ ÍBMAEV7$ç+ê ¿  !»endstreamendobj71 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter/FlateDecode/FormType 1/Length 76/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ*‰2T0 BCc=SëúÀe®gnÖ1Ù,ÕÕÕ`TL%sÈ"ãÍ"+ár@j í0q4y]®I(¬(:‡•qr «p!ïendstreamendobj72 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter[/FlateDecode]/FormType 1/Length 130/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+HâtOAÄ ªÔ|`Àq·æ¡DO¸ˇEdÉ â!°£Ìö¬$k‚%∏éÛÒ.P\ı:n(»ŒO)∆•ÇijÏYÏÌh∆ÏQ±Úìéñ4–√F:a˛oÌI§¥÷Åí»V¡¥πQœbo∑á˛Ï+?ÈhI=l¥†Øı+¿ ¨hE≥endstreamendobj73 0 obj<</BBox[0.0 0.0 7.08002 7.07999]/Filter/FlateDecode/FormType 1/Length 86/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+Hâ2–37±402VHÁ*‰2T0 BCc=SëúÀ¶†C=KSS#ïÉ(Â“E’EVÆUTëÑâ£…ÎBMBF—7(ç+ê ¿ 7&#^endstreamendobj77 0 obj<</BBox[0.0 0.0 70.56 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj168 0 obj<</JS(AFDate_FormatEx\("mm/dd/yyyy"\);)/S/JavaScript>>endobj169 0 obj<</JS(AFDate_KeystrokeEx\("mm/dd/yyyy"\);)/S/JavaScript>>endobj27 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj162 0 obj<</JS(AFSpecial_Format\(3\);)/S/JavaScript>>endobj163 0 obj<</JS(AFSpecial_Keystroke\(3\);)/S/JavaScript>>endobj70 0 obj<</BBox[0.0 0.0 116.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj69 0 obj<</BBox[0.0 0.0 116.28 14.88]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj68 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj166 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj167 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj26 0 obj<</BBox[0.0 0.0 116.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj160 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj161 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj158 0 obj<</JS(AFSpecial_Format\(2\);)/S/JavaScript>>endobj159 0 obj<</JS(AFSpecial_Keystroke\(2\);)/S/JavaScript>>endobj67 0 obj<</BBox[0.0 0.0 87.6 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj164 0 obj<</JS(AFSpecial_Format\(0\);)/S/JavaScript>>endobj165 0 obj<</JS(AFSpecial_Keystroke\(0\);)/S/JavaScript>>endobj66 0 obj<</BBox[0.0 0.0 20.28 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj65 0 obj<</BBox[0.0 0.0 116.76 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj25 0 obj<</BBox[0.0 0.0 37.92 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj24 0 obj<</BBox[0.0 0.0 37.92 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj23 0 obj<</BBox[0.0 0.0 146.64 14.4]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj64 0 obj<</BBox[0.0 0.0 242.64 14.16]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj63 0 obj<</BBox[0.0 0.0 242.64 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobj17 0 obj<</Names[(˛ˇ ~ i c o n + C o m m e n t + 2 5 5 : 2 5 5 : 0 - E N U - 0)80 0 R]>>endobj80 0 obj<</BBox[0.0 0.0 20.0 18.0]/Filter/FlateDecode/Length 326/Resources<<>>/Subtype/Form/Type/XObject>>stream
+HâLë1nÂ0DØ¬¢dâRõfÅrÇ ïÇ¸$pö4{˝•8îc|¿ˇçLár¢?$ˆKÙÛ∞«'%nâ˛—Aœv˙eGÈÂ5—ënôîk¶Ôï5ìtñLÁF“8w‡§¡IW:Ìo≥.Ÿ∏q*®9©∞¶Õ¬ΩÅ≠∞¡€…GN∞\‘ä!ã¢Oî[ÅpF®3RB!|tÉ›vﬁw<ÈÉûlˇáπv]áÿ‚·¢pısõ≤QƒL 
+è’f ·‚ËŸdø8=È~gl÷Ë€K≠≠–·1¬Àyﬁ√Æﬁ„@8ó+Ω§î’LÎÕKhãÍÑõÌx•Oq≥»‚*2z˜≈£¸¶˜y—·1¬Àyﬁ√ﬁ“wNuáwˆå C6i›…Ì€uT*˝N!s? Œu√I •¢q£˚m1$™}6\Á-‚˛` „Å£Üendstreamendobj8 0 obj<</BaseFont/Helvetica-Bold/Encoding 10 0 R/Name/HeBo/Subtype/Type1/Type/Font>>endobj9 0 obj<</BaseFont/Helvetica/Encoding 10 0 R/Name/Helv/Subtype/Type1/Type/Font>>endobj10 0 obj<</Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 160/Euro 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]/Type/Encoding>>endobj18 0 obj<</CreationDate(D:20090414174258-07'00')/Creator(Adobe InDesign CS3 \(5.0.4\))/Keywords(forms, flat, fillable)/ModDate(D:20140306175729+01'00')/Producer(Adobe PDF Library 8.0)/Subject(PDF forms)/Title(Example of an Interactive PDF Form)/Trapped/False>>endobjxref0 1960000000001 65535 f
+0000000002 00000 f
+0000000004 00000 f
+0000000612 00000 n
+0000000005 00000 f
+0000000006 00000 f
+0000000019 00000 f
+0000068806 00000 n
+0000074597 00000 n
+0000074691 00000 n
+0000074780 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000022378 00000 n
+0000074041 00000 n
+0000075972 00000 n
+0000000079 00000 f
+0000000016 00000 n
+0000022336 00000 n
+0000022431 00000 n
+0000073484 00000 n
+0000073299 00000 n
+0000073114 00000 n
+0000071992 00000 n
+0000070994 00000 n
+0000068003 00000 n
+0000068162 00000 n
+0000068356 00000 n
+0000068571 00000 n
+0000067200 00000 n
+0000067359 00000 n
+0000067553 00000 n
+0000067768 00000 n
+0000066405 00000 n
+0000066560 00000 n
+0000066750 00000 n
+0000066964 00000 n
+0000060867 00000 n
+0000061026 00000 n
+0000061220 00000 n
+0000061435 00000 n
+0000060064 00000 n
+0000060223 00000 n
+0000060417 00000 n
+0000060632 00000 n
+0000065602 00000 n
+0000065761 00000 n
+0000065955 00000 n
+0000066170 00000 n
+0000064705 00000 n
+0000065066 00000 n
+0000065272 00000 n
+0000062465 00000 n
+0000062624 00000 n
+0000062818 00000 n
+0000063033 00000 n
+0000061670 00000 n
+0000061825 00000 n
+0000062015 00000 n
+0000062229 00000 n
+0000073855 00000 n
+0000073669 00000 n
+0000072928 00000 n
+0000072743 00000 n
+0000072432 00000 n
+0000071679 00000 n
+0000071493 00000 n
+0000071307 00000 n
+0000069782 00000 n
+0000070053 00000 n
+0000070381 00000 n
+0000068898 00000 n
+0000069171 00000 n
+0000069499 00000 n
+0000070662 00000 n
+0000064536 00000 n
+0000000081 00000 f
+0000074138 00000 n
+0000000083 00000 f
+0000032837 00000 n
+0000000084 00000 f
+0000000085 00000 f
+0000000086 00000 f
+0000000089 00000 f
+0000048198 00000 n
+0000047594 00000 n
+0000000090 00000 f
+0000000093 00000 f
+0000035523 00000 n
+0000032418 00000 n
+0000000094 00000 f
+0000000097 00000 f
+0000000244 00000 n
+0000022305 00000 n
+0000000098 00000 f
+0000000099 00000 f
+0000000130 00000 f
+0000053201 00000 n
+0000053643 00000 n
+0000054084 00000 n
+0000054313 00000 n
+0000054540 00000 n
+0000055469 00000 n
+0000055717 00000 n
+0000056707 00000 n
+0000057629 00000 n
+0000057880 00000 n
+0000058127 00000 n
+0000059601 00000 n
+0000059821 00000 n
+0000058375 00000 n
+0000058623 00000 n
+0000064988 00000 n
+0000059108 00000 n
+0000059350 00000 n
+0000053417 00000 n
+0000053861 00000 n
+0000054767 00000 n
+0000054985 00000 n
+0000055225 00000 n
+0000055973 00000 n
+0000056231 00000 n
+0000056462 00000 n
+0000057241 00000 n
+0000057433 00000 n
+0000056980 00000 n
+0000058858 00000 n
+0000000131 00000 f
+0000000132 00000 f
+0000000133 00000 f
+0000000134 00000 f
+0000000135 00000 f
+0000000136 00000 f
+0000000139 00000 f
+0000032286 00000 n
+0000053087 00000 n
+0000000140 00000 f
+0000000141 00000 f
+0000000142 00000 f
+0000000143 00000 f
+0000000144 00000 f
+0000000145 00000 f
+0000000146 00000 f
+0000000150 00000 f
+0000047204 00000 n
+0000047333 00000 n
+0000046648 00000 n
+0000000151 00000 f
+0000000154 00000 f
+0000032322 00000 n
+0000032140 00000 n
+0000000155 00000 f
+0000000170 00000 f
+0000063268 00000 n
+0000063343 00000 n
+0000072305 00000 n
+0000072367 00000 n
+0000072178 00000 n
+0000072240 00000 n
+0000071180 00000 n
+0000071242 00000 n
+0000072616 00000 n
+0000072678 00000 n
+0000071865 00000 n
+0000071927 00000 n
+0000070847 00000 n
+0000070919 00000 n
+0000000171 00000 f
+0000000172 00000 f
+0000000173 00000 f
+0000000174 00000 f
+0000000175 00000 f
+0000000176 00000 f
+0000000177 00000 f
+0000000178 00000 f
+0000000179 00000 f
+0000000180 00000 f
+0000000181 00000 f
+0000000182 00000 f
+0000000183 00000 f
+0000000000 00000 f
+0000022822 00000 n
+0000000000 00000 f
+0000035485 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000023073 00000 n
+trailer<</Size 196/Root 20 0 R/Info 18 0 R/ID[<6F185C876244254CBA5693F8CDC7D0AA><07680517B50641EC873DCF06D522F846>]>>startxref76241%%EOF3 0 obj<</Length 21616/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c015 81.157285, 2014/12/12-00:43:15        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stMfs="http://ns.adobe.com/xap/1.0/sType/ManifestItem#"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmpMM:InstanceID>uuid:c39cada3-3682-2b43-86f0-ce007556145c</xmpMM:InstanceID>
+         <xmpMM:DocumentID>adobe:docid:indd:5235ff14-294b-11de-919f-d8c16f47bc75</xmpMM:DocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>5235ff13-294b-11de-919f-d8c16f47bc75</stRef:instanceID>
+            <stRef:documentID>adobe:docid:indd:87ea89f9-0d9e-11db-8dd1-d4ba47cf2fcb</stRef:documentID>
+         </xmpMM:DerivedFrom>
+         <xmpMM:Manifest>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stMfs:linkForm>ReferenceStream</stMfs:linkForm>
+                  <xmpMM:placedXResolution>72.00</xmpMM:placedXResolution>
+                  <xmpMM:placedYResolution>72.00</xmpMM:placedYResolution>
+                  <xmpMM:placedResolutionUnit>Inches</xmpMM:placedResolutionUnit>
+                  <stMfs:reference rdf:parseType="Resource">
+                     <stRef:instanceID>uuid:d510855e-e9ea-11da-af4a-001124384406</stRef:instanceID>
+                     <stRef:documentID>uuid:77F174B8EB4211DA8F94F7C9B41B7686</stRef:documentID>
+                  </stMfs:reference>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpMM:Manifest>
+         <xmp:CreateDate>2009-04-14T17:42:58-07:00</xmp:CreateDate>
+         <xmp:ModifyDate>2015-06-24T10:12:33+02:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2015-06-24T10:12:33+02:00</xmp:MetadataDate>
+         <xmp:CreatorTool>Adobe InDesign CS3 (5.0.4)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4AE0Fkb2JlAGQAAAAAAQUAAilI/9sAhAAKBwcHBwcKBwcKDgkJCQ4RDAsLDBEU&#xA;EBAQEBAUEQ8RERERDxERFxoaGhcRHyEhISEfKy0tLSsyMjIyMjIyMjIyAQsJCQ4MDh8XFx8rIh0i&#xA;KzIrKysrMjIyMjIyMjIyMjIyMjIyMjI+Pj4+PjJAQEBAQEBAQEBAQEBAQEBAQEBAQED/wAARCAEA&#xA;AMYDAREAAhEBAxEB/8QBogAAAAcBAQEBAQAAAAAAAAAABAUDAgYBAAcICQoLAQACAgMBAQEBAQAA&#xA;AAAAAAABAAIDBAUGBwgJCgsQAAIBAwMCBAIGBwMEAgYCcwECAxEEAAUhEjFBUQYTYSJxgRQykaEH&#xA;FbFCI8FS0eEzFmLwJHKC8SVDNFOSorJjc8I1RCeTo7M2F1RkdMPS4ggmgwkKGBmElEVGpLRW01Uo&#xA;GvLj88TU5PRldYWVpbXF1eX1ZnaGlqa2xtbm9jdHV2d3h5ent8fX5/c4SFhoeIiYqLjI2Oj4KTlJ&#xA;WWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+hEAAgIBAgMFBQQFBgQIAwNtAQACEQMEIRIxQQVRE2Ei&#xA;BnGBkTKhsfAUwdHhI0IVUmJy8TMkNEOCFpJTJaJjssIHc9I14kSDF1STCAkKGBkmNkUaJ2R0VTfy&#xA;o7PDKCnT4/OElKS0xNTk9GV1hZWltcXV5fVGVmZ2hpamtsbW5vZHV2d3h5ent8fX5/c4SFhoeIiY&#xA;qLjI2Oj4OUlZaXmJmam5ydnp+So6SlpqeoqaqrrK2ur6/9oADAMBAAIRAxEAPwCbeU/KflW58q6L&#xA;cXGi6fNNNp9rJJJJaws7u0MbMzM0ZJJJ3OKpt/gzyf8A9WHTf+kOD/qnirv8GeT/APqw6b/0hwf9&#xA;U8Vd/gzyf/1YdN/6Q4P+qeKu/wAGeT/+rDpv/SHB/wBU8Vd/gzyf/wBWHTf+kOD/AKp4q7/Bnk//&#xA;AKsOm/8ASHB/1TxV3+DPJ/8A1YdN/wCkOD/qnirv8GeT/wDqw6b/ANIcH/VPFXf4M8n/APVh03/p&#xA;Dg/6p4q7/Bnk/wD6sOm/9IcH/VPFXf4M8n/9WHTf+kOD/qnirv8ABnk//qw6b/0hwf8AVPFXf4M8&#xA;n/8AVh03/pDg/wCqeKu/wZ5P/wCrDpv/AEhwf9U8Vd/gzyf/ANWHTf8ApDg/6p4q7/Bnk/8A6sOm&#xA;/wDSHB/1TxV3+DPJ/wD1YdN/6Q4P+qeKu/wZ5P8A+rDpv/SHB/1TxV3+DPJ//Vh03/pDg/6p4q7/&#xA;AAZ5P/6sOm/9IcH/AFTxV3+DPJ//AFYdN/6Q4P8Aqnirv8GeT/8Aqw6b/wBIcH/VPFXf4M8n/wDV&#xA;h03/AKQ4P+qeKpTrPlPyrFqOgJFounok+oSRyqtrCA6Cwv5OLgR7jkimh7gYqm3kz/lD9B/7Ztn/&#xA;AMmI8VYl5g83anYazd2cLsI4X4qA1BSgP8pymWEyN8RHy/U5ePLERHpifx70u/xzrH87/wDB/wDN&#xA;uD8vL+fL7P1M/Gj/ADI/b+t3+OdY/nf/AIP/AJtx/Ly/ny+z9S+NH+ZH7f1u/wAc6x/O/wDwf/Nu&#xA;P5eX8+X2fqXxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8Awf8Azbj+Xl/P&#xA;l9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W4eedYP7b/wDB/wDNmP5eX8+X2fqY&#xA;y1EB/BH7f1t/441j+d/+D/5sx/Ly/ny+z9SPzUP5kft/W7/HGsfzv/wf/NmP5eX8+X2fqX81D+ZH&#xA;7f1u/wAcax/O/wDwf/NmP5eX8+X2fqX81D+ZH7f1u/xxrH87/wDB/wDNmP5eX8+X2fqX81D+ZH7f&#xA;1u/xxrH87/8AB/8ANmP5eX8+X2fqX81D+ZH7f1u/xxrH87/8H/zZj+Xl/Pl9n6l/NQ/mR+39bv8A&#xA;HGsfzv8A8H/zZj+Xl/Pl9n6l/NQ/mR+39bX+OdY/nf8A4P8A5sx/Ly/ny+z9TIZ4n+CP2/rd/jnW&#xA;P53/AOD/AObcfy8v58vs/Unxo/zI/b+t3+OdY/nf/g/+bcfy8v58vs/UvjR/mR+39bv8c6x/O/8A&#xA;wf8Azbj+Xl/Pl9n6l8aP8yP2/rd/jnWP53/4P/m3H8vL+fL7P1L40f5kft/W7/HOsfzv/wAH/wA2&#xA;4/l5fz5fZ+pfGj/Mj9v63f451j+d/wDg/wDm3H8vL+fL7P1L40f5kft/WyryPr15rUl4t2zMIVjK&#xA;8mr9ovXsPDJ48Zh/ET72jPMSqoge5NNd/wCOp5c/7aUn/dO1LLGh3kz/AJQ/Qf8Atm2f/JiPFXmv&#xA;m6n+JNQ/4y/8ari2gmtkn2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xW5O2xX1O2xX1O2xX1O2xX1O&#xA;2xX1O2xX1O2xX1O2xW5O2xW5O2xW5NH2xSCersLJ2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182n/AJ2TUP8AjL/xquLZVxSevvijh8nV98V4fJ1ffFeH&#xA;ydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFeHydX3xXh8nV&#xA;98V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFIjfRqpxZcAdU4rwB1a4UiIDO/wAr/wC+1H/Vh/XJgYZG&#xA;Ua7/AMdTy5/20pP+6dqWLW7yZ/yh+g/9s2z/AOTEeKvNfNv/ACkmof8AGX/jVcWyvSk+KK97sVr3&#xA;uxWve7Fa97sVr3uriyEHVxTwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8Dq4rwOrivA6uK8D&#xA;q4rwOrivA1WuFIjTO/yv/vtR/wBWH9cmBhkZRrv/AB1PLn/bSk/7p2pYtbvJn/KH6D/2zbP/AJMR&#xA;4q8183U/xJqFf9+/8ari2gmtkn2xW5dztsVuXc7bFbl3O2xW5dztsVuXc7bFbl3O2xW5dztsVuXc&#xA;7bFbl3O2xW5dzW2FIJ6uxZOxV2KuxV2KuxV2KuxV2KuxVnf5X/32o/6sP65MDXkZRrv/AB1PLn/b&#xA;Sk/7p2pYtbvJn/KH6D/2zbP/AJMR4q8182/8pJqH/GX/AI1XFs2oJPv4Yo273b+GK7d7t/DFdu92&#xA;/hiu3e7fwxXbvdv4Yrt3u38MV273b+GK7d7t/DFdu91adsUgA9XVxTwebq4rwebq4rwebq4rwebq&#xA;4rwebq4rwebq4rwebq4rwebVcLIRp2KXYqzv8r/77Uf9WH9cmBryMo13/jqeXP8AtpSf907UsWt3&#xA;kz/lD9B/7Ztn/wAmI8Vea+bqf4k1D/jL/wAari2i6SfbwxX1N8j4nBwhl4mTvdyPiceEL4mTva29&#xA;8LEmR6u2xX1O2xT6nbYr6nbYr6nbYr6nbYr6nAKe9MSSkRkeoboviPx/pgs9yeE94+11F8R+ONnu&#xA;RwnvDW2FHqdtivqdtivqdtivqawsnYq7FXYqzv8AK/8AvtR/1Yf1yYGvIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFXmvm6v+JNQp/v3/jVcWwVW6T74p9Dt8V9Dt8V9Dt8V9Dt8VBiGqHCn&#xA;jDqHFeMOocV4w6hxSJAuxS7FXYq7FXYq7FXYq7FXYq7FXYq7FWd/lf8A32o/6sP65MDXkZRrv/HU&#xA;8uf9tKT/ALp2pYtbvJn/ACh+g/8AbNs/+TEeKvNfNv8Aykmob/7t/wCNVxbBy5JP9OK/B304r8Hf&#xA;Tivwd9OK/B304r8HfTivwd9OK/B304r8HfTimz3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3Oo&#xA;MV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3OoMV4j3NHCyiSWd/lf/AH2o/wCrD+uTAwyMo13/AI6n&#xA;lz/tpSf907UsWt3kz/lD9B/7Ztn/AMmI8Vea+bf+Ul1D/jL/AMari2gXFJ6++KOHydX3xXh8nV98&#xA;V4fJ1ffFeHydX3xXh8nV98V4fJ1ffFRHyaqcLLgDqnFeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDqn&#xA;FeAOqcV4A6pxXgDqnFeAOqcV4A6pxXgDq4pEQGd/lf8A32o/6sP65MDDIyjXf+Op5c/7aUn/AHTt&#xA;Sxa3eTP+UP0H/tm2f/JiPFUn1fyKup6lcX5cj125U9Xj2A6fV38PHKpHNewFe/8AY5OOWERFmV/D&#xA;9aD/AOVbL/vw/wDI4f8AZLkeLP3R+Z/Uz49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98v&#xA;kP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q&#xA;/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9&#xA;bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1u&#xA;/wCVbL/vw/8AI4f9kuPFn7o/M/qXj0/fL5D9bv8AlWy/78P/ACOH/ZLjxZ+6PzP6l49P3y+Q/W7/&#xA;AJVsv+/D/wAjh/2S48Wfuj8z+pePT98vkP1oPVvJdno1m19eSP6SsFPCUE1Y0G31YYeLP3R+Z/Uo&#xA;lgPWXyH60i9Py3/Pc/8ABD/qhjefuj8z+plWDvl8h+t3p+W/57n/AIIf9UMbz90fmf1LWDvl8h+t&#xA;3p+W/wCe5/4If9UMbz90fmf1LWDvl8h+t3p+W/57n/gh/wBUMbz90fmf1LWDvl8h+t3p+W/57n/g&#xA;h/1QxvP3R+Z/UtYO+XyH63en5b/nuf8Agh/1QxvP3R+Z/UtYO+XyH63en5b/AJ7n/gh/1QxvP3R+&#xA;Z/UtYO+XyH63en5b/nuf+CH/AFQxvP3R+Z/UtYO+XyH63en5b/nuf+CH/VDG8/dH5n9S1g75fIfr&#xA;Zj+Xq6Yst9+j2lY8YufqEHu9KUjTJwOT+ID4NGo4NuG/inmu/wDHU8uf9tKT/unalk2h3kz/AJQ/&#xA;Qf8Atm2f/JiPFUZPeSRysNggNAB9ogAln5H4QARSh+/cDKJ5SC5GPCJRXWt48spik4kEEoy70KEK&#xA;6P7g/wARTbc4splKijLhEY2Ff6xFzdKmsZVW+E0q9OIBpQ9e2XNCx722QzBmI+rlVk+FjQvTiBtv&#xA;9odMVpd9Zh5lOW4Xn0PTb/moYrStirsVdirsVdirsVdirGfzA/5RuX/jLH/xLFlDm8owtzsVdirs&#xA;VdirsVdirsVdirO/yv8A77Uf9WH9cmBryMo13/jqeXP+2lJ/3TtSxa3eTP8AlD9B/wC2bZ/8mI8V&#xA;VdQiIdmliLxHZSqPLQEq7ApGrtXkvh4bg9cTPHfcbfP7nN089tjv8B9pVbCGQsszKyIqH7f2ndzz&#xA;ZqFVIAqaVA69BQZPDA3bXqJiiPxQRLWiM0r82UylGNKfCUpQrVT4d8yHGtDtaiQysUdTcmJ3FRRS&#xA;pAqKoeyCo3GKbbNvycSLCVaRFjLhhyVW615L+zwH34ravHNO1A0LKOIPIkbkkilNt6CvTFC+N5HN&#xA;HTiOKmte5rUbgHbFVTFXYq7FXYq7FWM/mB/yjcv/ABlj/wCJYsoc3lFMWzjDqYrxh1MV4w6mK8Yd&#xA;TFeMOpivGHUxXjDqYrxh1MV4wzv8sP77Uf8AVh/XJixyMo13/jqeXP8AtpSf907UsWt3kz/lD9B/&#xA;7Ztn/wAmI8VSvVZdXGoTiDR7m4iDfDKl3JGrCg3CKaDKJ6aEjZJ+Z/W5ENXOEaAH+lH6kJ62u/8A&#xA;Viu/+k6X/mrB+Th3y/00v1svz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX89k7o/6WP6ne&#xA;trv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw75f6aX61/PZO6&#xA;P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qd62u/9WK7/AOk6X/mrH8nDvl/ppfrX&#xA;89k7o/6WP6netrv/AFYrv/pOl/5qx/Jw75f6aX61/PZO6P8ApY/qd62u/wDViu/+k6X/AJqx/Jw7&#xA;5f6aX61/PZO6P+lj+p3ra7/1Yrv/AKTpf+asfycO+X+ml+tfz2Tuj/pY/qTAeYPNIFP8PPt/xcP+&#xA;acyHFb/xD5p/6l5v+Rw/5pxVDX2pa9qVubW98ttLESGKmam46dFyOTGJiizxZZY5WEt/R8//AFKR&#xA;/wCkg5R+Tx/0v9NL9bf+fy+XyH6k00Xy/Y3/AK36T0L9H+nw9OsrPz5cuXh0oPvx/J4/6X+ml+tf&#xA;z+Xy+Q/Umn+DvLv/ACxr/wAE3/NWP5PH/S/00v1r+fy+XyH6nf4O8u/8sa/8E3/NWP5PH/S/00v1&#xA;r+fy+XyH6nf4O8u/8sa/8E3/ADVj+Tx/0v8ATS/Wv5/L5fIfqd/g7y7/AMsa/wDBN/zVj+Tx/wBL&#xA;/TS/Wv5/L5fIfqd/g7y7/wAsa/8ABN/zVj+Tx/0v9NL9a/n8vl8h+p3+DvLv/LGv/BN/zVj+Tx/0&#xA;v9NL9a/n8vl8h+p3+DvLv/LGv/BN/wA1Y/k8f9L/AE0v1r+fy+XyH6kbp2i6bpJkawgEJlAD0JNe&#xA;NadSfHLcWGOPlfxJP3tWbUTy1f3BB67/AMdTy5/20pP+6dqWWNTvJn/KH6D/ANs2z/5MR4qmDalY&#xA;JN9Xa4QTVC+nX4uR6CmKq/qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/w&#xA;Df0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xV3qr4N/wDf0xVfirsVUp7iC2j9W4dYkBpyY0&#xA;FTiqjFqen3D+nBOkr9eKHkaD2GKoj1V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq&#xA;71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq71V8G/4Bv6Yq2rhuldvEEfrGKpPrv/HU8uf9tKT/&#xA;ALp2pYq7yZ/yh+g/9s2z/wCTEeKrppvKqX5Nx9RF+rgkssfrCQU47kcuXhiqa+qvg3/AN/TFXeqv&#xA;g3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/A&#xA;N/TFXeqvg3/AN/TFV+KuxVQu7a1u4TDeRLPESCUdeYqOm1DiqGtdM0iyl9ezs44JaEc44SpoeoqF&#xA;xVG+qvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXeqvg3/AN/TFXe&#xA;qvg3/AN/TFXeqvg3/AN/TFW1cN0rt4gj9YxVJ9d/46nlz/tpSf8AdO1LFXeTP+UP0H/tm2f/ACYj&#xA;xVbd3XlCK8c3v1FbxGBdpET1Aw6EsVrXFVf/ABR5e/6uEH/BjFXf4o8vf9XCD/gxirv8UeXv+rhB&#xA;/wAGMVd/ijy9/wBXCD/gxirv8UeXv+rhB/wYxVs+ZvL4AP6Rt9/8sHFWv8UeXv8Aq4Qf8GMVbPmb&#xA;y+KV1G338HB/ViqItNV0+/DNZTrchCAxiq1CeleIxVGYq7FVC7vLWxhNxeSrBECAXc0FT0xVA/4o&#xA;8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFXf4o8vf9XCD/AIPFWx5m0Agkahbmnb1F&#xA;B/4YjFWl8zaETvfQL7mWP+DnFUVaanaX6s9k63CoaMY2RgD4Gj4qiObf77b71/5qxV3Nv99t96/8&#xA;1Yq2rFuqlfnT+BOKpPrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/AOTEeKq9w/l0TuLtrIT1+MSm&#xA;LnX/ACuW+VS1OKJoyAPvbo6XNMWISI9xU/V8qfz6f98OR/N4P58fmGX5LUfzJfIu9Xyp/Pp/3w4/&#xA;m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bwfz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfI&#xA;u9Xyp/Pp/wB8OP5vB/Pj8wv5LUfzJfIu9Xyp/Pp/3w4/m8H8+PzC/ktR/Ml8i71fKn8+n/fDj+bw&#xA;fz4/ML+S1H8yXyLvV8qfz6f98OP5vB/Pj8wv5LUfzJfIqsGoeX7YEW1zZwhvtCOSJa08eJGP5vB/&#xA;Pj8wv5LUfzJfIpll7juxVQvDZCAm/MQgqKmfjwr2+3tkZzjAWTQZQxymaiLPkl/q+VP59P8Avhyr&#xA;83g/nx+YbvyWo/mS+Rd6vlT+fT/vhx/N4P58fmF/Jaj+ZL5F3q+VP59P++HH83g/nx+YX8lqP5kv&#xA;kXer5U/n0/74cfzeD+fH5hfyWo/mS+Rd6vlT+fT/AL4cfzeD+fH5hfyWo/mS+Rd6vlT+fT/vhx/N&#xA;4P58fmF/Jaj+ZL5FWh1Dy/bArb3VnCGNSI5IlBP+xIx/N4P58fmF/Jaj+ZL5FU/TOj/8t9t/yOT/&#xA;AJqx/N4P58fmF/Jaj+ZL5F36Z0f/AJb7b/kcn/NWP5vB/Pj8wv5LUfzJfIq1ve2d2WFpcRTlKcvS&#xA;dXpXpXiTlmPNDJ9JB9zXkwZMf1RI94SzXf8AjqeXP+2lJ/3TtSybW7yZ/wAofoP/AGzbP/kxHiqh&#xA;fw+bGvJTYpp5ti37szB/Up/lUwGMT0ZCch1Q/oed/wDfel/8C+Dgj3L4ku93oed/996X/wAC+PBH&#xA;uXxJd7vQ87/770v/AIF8eCPcviS73eh53/33pf8AwL48Ee5fEl3u9Dzv/vvS/wDgXx4I9y+JLvd6&#xA;Hnf/AH3pf/AvjwR7l8SXe70PO/8AvvS/+BfHgj3L4ku93oed/wDfel/8C+PBHuXxJd7vQ87/AO+9&#xA;L/4F8eCPcviS71T/AJ37/tW/8lMkxd/zv3/at/5KYq0y+fHFGGmsPAiQ4CAUgkclnoed/wDfel/8&#xA;C+Dgj3J8SXe70PO/++9L/wCBfHgj3L4ku93oed/996X/AMC+PBHuXxJd7vQ87/770v8A4F8eCPcv&#xA;iS73eh53/wB96X/wL48Ee5fEl3u9Dzv/AL70v/gXx4I9y+JLvRFlB5r+txfpCPTvqtf3vpK3On+T&#xA;y2x4I9y+JLvT30IP99p/wIx4I9y+JLvd6EH++0/4EY8Ee5fEl3rljjT7Cha9aADCIgckGRPNJ9d/&#xA;46nlz/tpSf8AdO1LCh3kz/lD9B/7Ztn/AMmI8VX3XmnRLK4ktbm5CSxHi606HFVH/Gfl3/lrH3HF&#xA;Xf4z8u/8tY+44q7/ABn5d/5ax9xxV3+M/Lv/AC1r9xxVtvOXlwGgvFb3AP8AEDFU0tryO7gS5tla&#xA;SKUckccaEeO7Yqq82/3233r/AM1Yq7m3++2+9f8AmrFXc2/3233r/wA1YqvxV2KoTUdStNJtTeXz&#xA;mOFSFLAFt22GygnFUFp3mnRtVuPqlhK00xUtx4Muw67uFGKprzb/AH233r/zVirubf77b71/5qxV&#xA;3Nv99t96/wDNWKu5t/vtvvX/AJqxV3Nv99t96/8ANWKu5t/vtvvX/mrFXc2/3233r/zVirubf77b&#xA;71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxVNzFETUopJ7kDFXe&#xA;jD/vtfuGKu9GH/fa/cMVd6MP++1+4Yq70Yf99r9wxV3ow/77X7hiq4AAUAoB2GKt4q7FXYq7FXYq&#xA;hNR1K00m1N5fOY4VIUsAW3bYbKCcVSj/AB35Z/5aW/5FSf8ANOKu/wAd+Wf+Wlv+RUn/ADTirv8A&#xA;Hfln/lpb/kVJ/wA04q7/AB35Z/5aW/5FSf8ANOKtjz15YIJ+tkEdvSlqf+ExVr/Hfln/AJaW/wCR&#xA;Un/NOKq9l5v0LULqOzs5mknlJCJ6brWgLHdgB0GKpxzb/fbfev8AzVirubf77b71/wCasVbVi3VS&#xA;vzp/AnFUn13/AI6nlz/tpSf907UsVd5M/wCUP0H/ALZtn/yYjxVGzavp0ErQyzcXQ0YcXND9C5VL&#xA;U44miXIho8042Bss/Tulf7//AOEf/mnI/m8Xey/IZ/5v3O/Tulf7/wD+Ef8A5px/N4u9fyGf+b9z&#xA;v07pX+//APhH/wCacfzeLvX8hn/m/c79O6V/v/8A4R/+acfzeLvX8hn/AJv3O/Tulf7/AP8AhH/5&#xA;px/N4u9fyGf+b9zv07pX+/8A/hH/AOacfzeLvX8hn/m/c79O6V/v/wD4R/8AmnH83i71/IZ/5v3O&#xA;/Tulf7//AOEf/mnH83i71/IZ/wCb9zv07pX+/wD/AIR/+acfzeLvX8hn/m/cmGXuK7FVK4uYbSIz&#xA;XDcEBArQnc/6oORnOMBZZ48UskqjzQn6d0r/AH//AMI//NOVfm8Xe3/kM/8AN+536d0r/f8A/wAI&#xA;/wDzTj+bxd6/kM/837nfp3Sv9/8A/CP/AM04/m8Xev5DP/N+536d0r/f/wDwj/8ANOP5vF3r+Qz/&#xA;AM37nfp3Sv8Af/8Awj/804/m8Xev5DP/ADfud+ndK/3/AP8ACP8A804/m8Xev5DP/N+536d0r/f/&#xA;APwj/wDNOP5vF3r+Qz/zfud+ndK/3/8A8I//ADTj+bxd6/kM/wDN+536d0r/AH//AMI//NOP5vF3&#xA;r+Qz/wA37le1v7S9LC2k5lKcvhYUr/rAZPHmhk5Fqy6fJi+oJdrv/HU8uf8AbSk/7p2pZY1O8mf8&#xA;ofoP/bNs/wDkxHiqhf2HnCW8lksNUhgtmasUTRKxUU6EmJv14qh/0Z58/wCrzB/yJT/qhirv0Z58&#xA;/wCrzB/yJT/qhirv0Z58/wCrzB/yJT/qhiqvBaedYVKyX9ncEmvKWIig8B6Sx4qq+l5y/wCWjT/+&#xA;Rcv/ADViqHnsfPEzho9TtLcAU4xxVBO+/wC8SQ/jiqn+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8A&#xA;kSn/AFQxV36M8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M&#xA;8+f9XmD/AJEp/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp&#xA;/wBUMVd+jPPn/V5g/wCRKf8AVDFXfozz5/1eYP8AkSn/AFQxV36M8+f9XmD/AJEp/wBUMVTfRrfW&#xA;reKRdau0vJGYGNo0CBVp0+FE74qmWKuxV2KpLrv/AB1PLn/bSk/7p2pYq7yZ/wAofoP/AGzbP/kx&#xA;Hiqbky12VSPdiP8AjXFXVm/lX/gj/wA0Yq6s38q/8Ef+aMVdWb+Vf+CP/NGKurN/Kv8AwR/5oxV1&#xA;Zv5V/wCCP/NGKurN/Kv/AAR/5oxV1Zv5V/4I/wDNGKurN/Kv/BH/AJoxV1Zv5V/4I/8ANGKr8Vdi&#xA;qnOvKMjjz9q0xViF3pVw91O48tPMGkciUamU51Y/Fw5/DXrTFU+0XSLSxjW6jtGs7mZAJYmnefjv&#xA;XjyZ2X6Riqa4qh76S7htZJbKEXM6iqQlgnPfpybYYqkv6W83f9WBf+kuLFXfpbzd/wBWBf8ApLix&#xA;VN9Nmv7i2Euo2ws5iSPRDiSgHQ81NN8VReKuxV2KpLrv/HU8uf8AbSk/7p2pYq7yZ/yh+g/9s2z/&#xA;AOTEeKpVquna/NqM8lrpOn3ELNVJZq+owoN2/fL+rKJ6TDM2YglyIa3PCNCRAQn6K8zf9WPS/uP/&#xA;AFXyP5HT/wAwMv5R1P8APKrb6Zrikm68v6fKP2RG/pmviSzyfqx/I6f+YF/lHU/zyr/o+/8A+pZs&#xA;/wDpIX/mjH8jp/5gX+UdT/PLv0ff/wDUs2f/AEkL/wA0Y/kdP/MC/wAo6n+eXfo+/wD+pZs/+khf&#xA;+aMfyOn/AJgX+UdT/PKaWGiWM1uHv9Kt7WepBjUiQAdjyAGP5HT/AMwL/KOp/nlE/wCH9E/5YYf+&#xA;BGP5HT/zAv8AKOp/nl3+H9E/5YYf+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf5&#xA;5d/h/RP+WGH/AIEY/kdP/MC/yjqf55d/h/RP+WGH/gRj+R0/8wL/ACjqf55d/h/RP+WGH/gRj+R0&#xA;/wDMC/yjqf55d/h/RP8Alhh/4EY/kdP/ADAv8o6n+eXf4f0T/lhh/wCBGP5HT/zAv8o6n+eXf4f0&#xA;T/lhh/4EY/kdP/MC/wAo6n+eXf4f0T/lhh/4EY/kdP8AzAv8o6n+eXf4f0T/AJYYf+BGP5HT/wAw&#xA;L/KOp/nl3+H9E/5YYf8AgRj+R0/8wL/KOp/nl3+H9E/5YYf+BGP5HT/zAv8AKOp/nl3+H9E/5YYf&#xA;+BGP5HT/AMwL/KOp/nl3+H9E/wCWGH/gRj+R0/8AMC/yjqf55RFpp1jYljZwJAZKcuApWnSv35bi&#xA;wY8X0imrNqcuauKVpdrv/HU8uf8AbSk/7p2pZY1O8mf8ofoP/bNs/wDkxHiqzW4ZJLdhHDeSn1lN&#xA;LOQRPSku/Iharv4ntiqR/Urn/li1v/pLX/mrFXfUrn/li1v/AKS1/wCasVTjStCR1hvpZdRt5EcP&#xA;9XuLkt9htg4FQQaYqyHFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FUl13/jqeXP+&#xA;2lJ/3TtSxV3kz/lD9B/7Ztn/AMmI8VXa5ZCW1AS3uLotKrFLaVYXFBJ8RaqVHxdK4qk0OjLIzCWw&#xA;1GABSwZ7wsCR0Uem7mp99sVU/wBFP/1adT/6TV/6rYqitPiudNnNxBpGoM5UpSW6jkWhoejSnwxV&#xA;NE1fVGdVbRrhFYgFjJDQA99pMVTfFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYqkuu/&#xA;8dTy5/20pP8AunalirvJn/KH6D/2zbP/AJMR4qq+YLQ3lkkQs3v6ShvSimEBFFccuZZa9aUxVJ7D&#xA;SWgkkY6NPa8o3Xk92Jw1R9gKDLQn+ag+eKoX9Bt/1L1z/wBxFf8Aqtirv0G3/UvXP/cRX/qtiqYa&#xA;R5ftjcCe50yewe3ZJIi92ZgzA1+ykjdKd8VZPirsVdirsVdirsVdiqHvb620+A3N3IIogQCzEAVP&#xA;TriqXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVd/i3QP+WyP/AIJf+asVd/i3QP8Alsj/AOCX&#xA;/mrFXf4t0D/lsj/4Jf8AmrFXf4t0D/lsj/4Jf+asVbXzXoLMFW7jJJoByXqf9liqa82/3233r/zV&#xA;irubf77b71/5qxVtWLdVK/On8CcVSfXf+Op5c/7aUn/dO1LFXeTP+UP0H/tm2f8AyYjxV3mC2GoW&#xA;ggm09b9Y5lZY3na3HSRefMAV+Xv7Yqg9F0HSoBJPJp6abOwaLit0bjlGwFd2NBv7VxVU/wAG+Uf+&#xA;WVf+R8v/AFVxVcPJPlVhVbIEeImmP/M3FW/8D+V/+WH/AJKzf9VcVTexsbXTbVLKyT0oIq8EqWpy&#xA;Jc7uSepxVEYq7FXYq7FXYq7FVrxxyrwkUOvgwBH44qpfUrP/AJZ4v+AX+mKu+pWf/LPF/wAAv9MV&#xA;d9Ss/wDlni/4Bf6Yq76lZ/8ALPF/wC/0xV31Kz/5Z4v+AX+mKu+pWf8Ayzxf8Av9MVd9TsxuII/+&#xA;AX+mKq+KuxV2KpLrv/HU8uf9tKT/ALp2pYq7yZ/yh+g/9s2z/wCTEeKo280fT9QQxXsInjLiTi2w&#xA;DDnQ/DQ/tnFUF/g/y1/ywR/e/wDzVirv8H+Wv+WCP73/AOasVTOzsrXT7dbWzjEMKVKoK0FTU9a9&#xA;ziqvirsVSjzLa3l5pvo2FfW9RSCpINBWu4zG1uPJkxEQ5uZ2dlx4s1z5MNPlzzcSSJ5AOw5HKI6e&#xA;QAuJ/wBOXKnqYGRrIK/qBr/Dfm//AH/J/wAEcP5c/wA0/wCnLH8xH/VB/wAqwq23l7zTHKrTSSOo&#xA;YEjk3QHfKsulzEjhBG+/qJbsOrwRB45CXd6AHoaAhFB60GbR0q7FUt163ubnTZIbSvrN9niaH8Mp&#xA;1MJTxER5uRo8kIZomXJhL+XPNjGqTSKPDkxzBwaXLGFTBJ/rl2WfV4ZyuEhEd3ACt/w35v8A9/yf&#xA;8Ect/Ln+af8ATlp/MR/1Qf8AKsL4/LvmtQeckj+HxsMx9To9ROuC4/5xcnTa3TQB4yJf5oD0G1Vk&#xA;tYUcUZY1DA+IArm2HJ0kyDIq2Fi7FXYq7FXYq7FUl13/AI6nlz/tpSf907UsVSnyn5s8q23lXRbe&#xA;41rT4ZodPtY5I5LqFXR1hjVlZWkBBBG4xVNv8Z+T/wDq/ab/ANJkH/VTFXf4z8n/APV+03/pMg/6&#xA;qYq7/Gfk/wD6v2m/9JkH/VTFXf4z8n/9X7Tf+kyD/qpirv8AGfk//q/ab/0mQf8AVTFXf4z8n/8A&#xA;V+03/pMg/wCqmKu/xn5P/wCr9pv/AEmQf9VMVd/jPyf/ANX7Tf8ApMg/6qYq7/Gfk/8A6v2m/wDS&#xA;ZB/1UxV3+M/J/wD1ftN/6TIP+qmKu/xn5P8A+r9pv/SZB/1UxV3+M/J//V+03/pMg/6qYq7/ABn5&#xA;P/6v2m/9JkH/AFUxV3+M/J//AFftN/6TIP8Aqpirv8Z+T/8Aq/ab/wBJkH/VTFXf4z8n/wDV+03/&#xA;AKTIP+qmKu/xn5P/AOr9pv8A0mQf9VMVd/jPyf8A9X7Tf+kyD/qpirv8Z+T/APq/ab/0mQf9VMVd&#xA;/jPyf/1ftN/6TIP+qmKu/wAZ+T/+r9pv/SZB/wBVMVd/jPyf/wBX7Tf+kyD/AKqYq7/Gfk//AKv2&#xA;m/8ASZB/1UxVKdZ82eVZdR0B4ta090g1CSSVluoSEQ2F/HyciTYcnUVPcjFX/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Example of an Interactive PDF Form</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">PDF forms</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:creator>
+            <rdf:Bag/>
+         </dc:creator>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>forms</rdf:li>
+               <rdf:li>flat</rdf:li>
+               <rdf:li>fillable</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+         <pdf:Producer>Adobe PDF Library 8.0</pdf:Producer>
+         <pdf:Trapped>False</pdf:Trapped>
+         <pdf:Keywords>forms, flat, fillable</pdf:Keywords>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj18 0 obj<</CreationDate(D:20090414174258-07'00')/Creator(Adobe InDesign CS3 \(5.0.4\))/Keywords(forms, flat, fillable)/ModDate(D:20150624101233+02'00')/Producer(Adobe PDF Library 8.0)/Subject(PDF forms)/Title(Example of an Interactive PDF Form)/Trapped/False>>endobj20 0 obj<</AcroForm 95 0 R/Extensions<</ADBE<</BaseVersion/1.7/ExtensionLevel 3>>>>/MarkInfo<</Marked false>>/Metadata 3 0 R/Names 96 0 R/OpenAction 21 0 R/Outlines 196 0 R/Pages 16 0 R/Type/Catalog/ViewerPreferences<</Direction/L2R>>>>endobj122 0 obj<</AA<<>>/AP<</N 197 0 R>>/DA(/Helv  0 Tf 0 g)/DR<</Encoding<</PDFDocEncoding 157 0 R>>/Font<</Helv 156 0 R>>>>/F 4/FT/Tx/P 22 0 R/Rect[491.28 602.19 578.88 620.91]/Subtype/Widget/T(ZIP)/TU(ZIP)/Type/Annot>>endobj196 0 obj<</Count 0/Type/Outlines>>endobj197 0 obj<</BBox[0.0 0.0 87.6 18.72]/FormType 1/Length 13/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ProcSet[/PDF]>>/Subtype/Form/Type/XObject>>stream
+/Tx BMC 
+EMC
+endstreamendobjxref0 10000000000 65535 f
+3 10000080313 00000 n
+18 10000102006 00000 n
+20 10000102275 00000 n
+122 10000102520 00000 n
+196 20000102745 00000 n
+0000102789 00000 n
+trailer<</Size 198/Root 20 0 R/Info 18 0 R/ID[<6F185C876244254CBA5693F8CDC7D0AA><325E0E181BDC473D94BF4D6DD2CA5B68>]/Prev 76241>>startxref102974%%EOF

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1436,8 +1436,15 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     }
 }
 
-- (void)removeAnnotationWithUUID:(CDVInvokedUrlCommand *)command {
-    NSString *annotationUUID = [command argumentAtIndex:0];
+- (void)removeAnnotation:(CDVInvokedUrlCommand *)command {
+    id jsonAnnotation = [command argumentAtIndex:0];
+    NSString *annotationUUID = jsonAnnotation[@"uuid"];
+    if (annotationUUID.length == 0) {
+        NSLog(@"Invalid annotation UUID.");
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
+                                    callbackId:command.callbackId];
+    }
+    
     PSPDFDocument *document = self.pdfController.document;
     VALIDATE_DOCUMENT(document)
     BOOL success = NO;

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -407,7 +407,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     if (path.isAbsolutePath) {
         xfdfFileURL = [self pdfFileURLWithPath:path];
     } else {
-        // Create the XFDF file in the ~/Documents directory
+        // Locate the XFDF file in the ~/Documents directory
         NSString *docsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
         xfdfFileURL = [NSURL fileURLWithPath:[docsFolder stringByAppendingPathComponent:path]];
     }

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1502,13 +1502,13 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)addAnnotations:(CDVInvokedUrlCommand *)command {
-    id jsonAnnotations = [command argumentAtIndex:0];
+- (void)applyInstantJSON:(CDVInvokedUrlCommand *)command {
+    id jsonValue = [command argumentAtIndex:0];
     NSData *data;
-    if ([jsonAnnotations isKindOfClass:NSString.class]) {
-        data = [jsonAnnotations dataUsingEncoding:NSUTF8StringEncoding];
-    } else if ([jsonAnnotations isKindOfClass:NSDictionary.class])  {
-        data = [NSJSONSerialization dataWithJSONObject:jsonAnnotations options:0 error:nil];
+    if ([jsonValue isKindOfClass:NSString.class]) {
+        data = [jsonValue dataUsingEncoding:NSUTF8StringEncoding];
+    } else if ([jsonValue isKindOfClass:NSDictionary.class])  {
+        data = [NSJSONSerialization dataWithJSONObject:jsonValue options:0 error:nil];
     } else {
         NSLog(@"Invalid JSON Annotations.");
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -447,7 +447,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
         // Create the folder where the XFDF file will be saved.
         NSError *createFolderError;
         if (![[NSFileManager defaultManager] createDirectoryAtPath:[xfdfFileURL.path stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
-            NSLog(@"Failed to create 'www' directory: %@", createFolderError.localizedDescription);
+            NSLog(@"Failed to create directory: %@", createFolderError.localizedDescription);
             return;
         }
 
@@ -1111,8 +1111,17 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 - (void)present:(CDVInvokedUrlCommand *)command {
     NSString *path = [command argumentAtIndex:0];
     NSDictionary *options = [command argumentAtIndex:1] ?: [command argumentAtIndex:2];
-    NSString *xfdfFile = [command argumentAtIndex:2] ?: [command argumentAtIndex:3];
 
+    // Validate the options dictionary
+    if (![options isKindOfClass:NSDictionary.class]) {
+        options = nil;
+    }
+
+    // Validate the xfdf file path
+    NSString *xfdfFilePath = [command argumentAtIndex:2] ?: [command argumentAtIndex:3] ?: [command argumentAtIndex:1];
+    if (![xfdfFilePath isKindOfClass:NSString.class]) {
+        xfdfFilePath = nil;
+    }
     // merge options with defaults
     NSMutableDictionary *newOptions = [self.defaultOptions mutableCopy];
     [newOptions addEntriesFromDictionary:options];
@@ -1142,8 +1151,8 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     [self setOptions:newOptions forObject:_pdfController animated:NO];
 
     // Handle XFDF
-    if (xfdfFile.length > 0) {
-        [self createXFDFDocumentWithPath:xfdfFile];
+    if (xfdfFilePath.length > 0) {
+        [self createXFDFDocumentWithPath:xfdfFilePath];
     }
 
     _pdfController.document = _pdfDocument;

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -32,8 +32,7 @@
 
 #pragma mark Private methods
 
-- (NSDictionary *)defaultOptions
-{
+- (NSDictionary *)defaultOptions {
     //this is an opportunity to provide
     //default options if we so choose
     if (!_defaultOptions) {
@@ -42,8 +41,7 @@
     return _defaultOptions;
 }
 
-- (void)setOptionsWithDictionary:(NSDictionary *)options animated:(BOOL)animated
-{
+- (void)setOptionsWithDictionary:(NSDictionary *)options animated:(BOOL)animated {
     //merge with defaults
     NSMutableDictionary *newOptions = [self.defaultOptions mutableCopy];
     [newOptions addEntriesFromDictionary:options];
@@ -56,8 +54,7 @@
     [self setOptions:options forObject:_pdfController animated:animated];
 }
 
-- (void)setOptions:(NSDictionary *)options forObject:(id)object animated:(BOOL)animated
-{
+- (void)setOptions:(NSDictionary *)options forObject:(id)object animated:(BOOL)animated {
     if (object) {
 
         //merge with defaults
@@ -98,17 +95,14 @@
     }
 }
 
-- (id)optionAsJSON:(NSString *)key
-{
+- (id)optionAsJSON:(NSString *)key {
     id value = nil;
     NSString *getterString = [key stringByAppendingFormat:@"AsJSON"];
     if ([self respondsToSelector:NSSelectorFromString(getterString)]) {
         value = [self valueForKey:getterString];
-    }
-    else if ([_pdfDocument respondsToSelector:NSSelectorFromString(key)]) {
+    } else if ([_pdfDocument respondsToSelector:NSSelectorFromString(key)]) {
         value = [_pdfDocument valueForKey:key];
-    }
-    else if ([_pdfController respondsToSelector:NSSelectorFromString(key)]) {
+    } else if ([_pdfController respondsToSelector:NSSelectorFromString(key)]) {
         value = [_pdfController valueForKey:key];
     }
 
@@ -117,17 +111,14 @@
         [value isKindOfClass:[NSDictionary class]] ||
         [value isKindOfClass:[NSArray class]]) {
         return value;
-    }
-    else if ([value isKindOfClass:[NSSet class]]) {
+    } else if ([value isKindOfClass:[NSSet class]]) {
         return [value allObjects];
-    }
-    else {
+    } else {
         return [value description];
     }
 }
 
-- (NSDictionary *)dictionaryWithError:(NSError *)error
-{
+- (NSDictionary *)dictionaryWithError:(NSError *)error {
     if (error) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         dict[@"code"] = @(error.code);
@@ -139,8 +130,7 @@
     return nil;
 }
 
-- (NSDictionary *)standardColors
-{
+- (NSDictionary *)standardColors {
     //TODO: should we support all the standard css color names here?
     static NSDictionary *colors = nil;
     if (colors == nil) {
@@ -165,8 +155,7 @@
     return colors;
 }
 
-- (UIColor *)colorWithString:(NSString *)string
-{
+- (UIColor *)colorWithString:(NSString *)string {
     //convert to lowercase
     string = [string lowercaseString];
 
@@ -209,8 +198,7 @@
 
     //try hex
     string = [string stringByReplacingOccurrencesOfString:@"#" withString:@""];
-    switch ([string length])
-    {
+    switch ([string length]) {
         case 0:
         {
             string = @"00000000";
@@ -243,12 +231,10 @@
     return [UIColor colorWithRed:red green:green blue:blue alpha:1.0f];
 }
 
-- (void)getComponents:(CGFloat *)rgba ofColor:(UIColor *)color
-{
+- (void)getComponents:(CGFloat *)rgba ofColor:(UIColor *)color {
     CGColorSpaceModel model = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));
     const CGFloat *components = CGColorGetComponents(color.CGColor);
-    switch (model)
-    {
+    switch (model) {
         case kCGColorSpaceModelMonochrome:
         {
             rgba[0] = components[0];
@@ -276,8 +262,7 @@
     }
 }
 
-- (NSString *)colorAsString:(UIColor *)color
-{
+- (NSString *)colorAsString:(UIColor *)color {
     //get components
     CGFloat rgba[4];
     [self getComponents:rgba ofColor:color];
@@ -301,20 +286,15 @@
 }
 
 // http://stackoverflow.com/questions/5225130/grand-central-dispatch-gcd-vs-performselector-need-a-better-explanation/5226271#5226271
-void runOnMainQueueWithoutDeadlocking(void (^block)(void))
-{
-    if ([NSThread isMainThread])
-    {
+void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
+    if ([NSThread isMainThread]) {
         block();
-    }
-    else
-    {
+    } else {
         dispatch_sync(dispatch_get_main_queue(), block);
     }
 }
 
-- (BOOL)sendEventWithJSON:(id)JSON
-{
+- (BOOL)sendEventWithJSON:(id)JSON {
     if ([JSON isKindOfClass:[NSDictionary class]]) {
         JSON = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:JSON options:0 error:NULL] encoding:NSUTF8StringEncoding];
     }
@@ -323,20 +303,17 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return [result length]? [result boolValue]: YES;
 }
 
-- (BOOL)isNumeric:(id)value
-{
+- (BOOL)isNumeric:(id)value {
     if ([value isKindOfClass:[NSNumber class]]) return YES;
     static NSNumberFormatter *formatter = nil;
-    if (formatter == nil)
-    {
+    if (formatter == nil) {
         formatter = [[NSNumberFormatter alloc] init];
         formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
     }
     return [formatter numberFromString:value] != nil;
 }
 
-- (UIBarButtonItem *)standardBarButtonWithName:(NSString *)name
-{
+- (UIBarButtonItem *)standardBarButtonWithName:(NSString *)name {
     NSString *selectorString = [name stringByAppendingString:@"ButtonItem"];
     if ([_pdfController respondsToSelector:NSSelectorFromString(selectorString)]) {
         return [_pdfController valueForKey:selectorString];
@@ -344,13 +321,10 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return nil;
 }
 
-- (UIBarButtonItem *)barButtonItemWithJSON:(id)JSON
-{
+- (UIBarButtonItem *)barButtonItemWithJSON:(id)JSON {
     if ([JSON isKindOfClass:[NSString class]]) {
         return [self standardBarButtonWithName:JSON];
-    }
-    else if ([JSON isKindOfClass:[NSDictionary class]]) {
-
+    } else if ([JSON isKindOfClass:[NSDictionary class]]) {
         UIImage *image = nil;
         NSString *imagePath = JSON[@"image"];
         if (imagePath) {
@@ -383,8 +357,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return nil;
 }
 
-- (NSArray *)barButtonItemsWithArray:(NSArray *)array
-{
+- (NSArray *)barButtonItemsWithArray:(NSArray *)array {
     NSMutableArray *items = [NSMutableArray array];
     for (id JSON in array) {
         UIBarButtonItem *item = [self barButtonItemWithJSON:JSON];
@@ -398,8 +371,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return items;
 }
 
-- (void)customBarButtonItemAction:(UIBarButtonItem *)sender
-{
+- (void)customBarButtonItemAction:(UIBarButtonItem *)sender {
     NSInteger index = [_pdfController.navigationItem.leftBarButtonItems indexOfObject:sender];
     if (index == NSNotFound) {
         index = [_pdfController.navigationItem.rightBarButtonItems indexOfObject:sender];
@@ -407,15 +379,13 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
             NSString *script = [NSString stringWithFormat:@"PSPDFKitPlugin.dispatchRightBarButtonAction(%ld)", (long)index];
             [self stringByEvaluatingJavaScriptFromString:script];
         }
-    }
-    else {
+    } else {
         NSString *script = [NSString stringWithFormat:@"PSPDFKitPlugin.dispatchLeftBarButtonAction(%ld)", (long)index];
         [self stringByEvaluatingJavaScriptFromString:script];
     }
 }
 
-- (NSURL *)pdfFileURLWithPath:(NSString *)path
-{
+- (NSURL *)pdfFileURLWithPath:(NSString *)path {
     if (path) {
         path = [path stringByExpandingTildeInPath];
         path = [path stringByReplacingOccurrencesOfString:@"file:" withString:@""];
@@ -485,16 +455,14 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     _pdfDocument = document;
 }
 
-- (NSInteger)enumValueForKey:(NSString *)key ofType:(NSString *)type withDefault:(int)defaultValue
-{
+- (NSInteger)enumValueForKey:(NSString *)key ofType:(NSString *)type withDefault:(int)defaultValue {
     NSNumber *number = key? [self enumValuesOfType:type][key]: nil;
     if (number) return [number integerValue];
     if ([self isNumeric:key]) return [key integerValue];
     return defaultValue;
 }
 
-- (NSString *)enumKeyForValue:(int)value ofType:(NSString *)type
-{
+- (NSString *)enumKeyForValue:(int)value ofType:(NSString *)type {
     NSDictionary *dict = [self enumValuesOfType:type];
     NSInteger index = [[dict allValues] indexOfObject:@(value)];
     if (index != NSNotFound) {
@@ -503,10 +471,8 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return nil;
 }
 
-- (NSInteger)optionsValueForKeys:(NSArray *)keys ofType:(NSString *)type withDefault:(NSInteger)defaultValue
-{
-    if (!keys)
-    {
+- (NSInteger)optionsValueForKeys:(NSArray *)keys ofType:(NSString *)type withDefault:(NSInteger)defaultValue {
+    if (!keys) {
         return 0;
     }
     if ([keys isKindOfClass:NSNumber.class]) {
@@ -514,17 +480,14 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
             return 0;
         }
     }
-    if (![keys isKindOfClass:[NSArray class]])
-    {
+    if (![keys isKindOfClass:[NSArray class]]) {
         keys = @[keys];
     }
-    if ([keys count] == 0)
-    {
+    if ([keys count] == 0) {
         return defaultValue;
     }
     NSInteger value = 0;
-    for (id key in keys)
-    {
+    for (id key in keys) {
         NSNumber *number = [self enumValuesOfType:type][key];
         if (number)
         {
@@ -550,12 +513,10 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return value;
 }
 
-- (NSArray *)optionKeysForValue:(NSUInteger)value ofType:(NSString *)type
-{
+- (NSArray *)optionKeysForValue:(NSUInteger)value ofType:(NSString *)type {
     NSDictionary *dict = [self enumValuesOfType:type];
     NSMutableArray *keys = [NSMutableArray array];
-    for (NSString *key in dict)
-    {
+    for (NSString *key in dict) {
         NSNumber *number = dict[key];
         if (number) {
             if ([number unsignedIntegerValue] == NSUIntegerMax)
@@ -575,8 +536,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     return keys;
 }
 
-- (void)resetBarButtonItemsIfNeededForOptions:(NSDictionary *)options
-{
+- (void)resetBarButtonItemsIfNeededForOptions:(NSDictionary *)options {
     // Reset left- and rightBarButtonItems to not cause duplicated button issues
     if ([options.allKeys containsObject:@"leftBarButtonItems"] && [options.allKeys containsObject:@"rightBarButtonItems"]) {
         NSDictionary *resetBarButtonsOptions = @{@"leftBarButtonItems": @[], @"rightBarButtonItems": @[]};
@@ -586,8 +546,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark Enums and options
 
-- (NSDictionary *)enumValuesOfType:(NSString *)type
-{
+- (NSDictionary *)enumValuesOfType:(NSString *)type {
     static NSDictionary *enumsByType = nil;
     if (!enumsByType) {
         enumsByType = @{
@@ -703,20 +662,20 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                               @"sepia": @(PSPDFAppearanceModeSepia),
                               @"night": @(PSPDFAppearanceModeNight)},
 
-//                        @"PSPDFDocumentSharingOptions":
-//
-//                            @{@"None": @(PSPDFDocumentSharingOptionNone),
-//                              @"CurrentPageOnly": @(PSPDFDocumentSharingOptionCurrentPageOnly),
-//                              @"PageRange": @(PSPDFDocumentSharingOptionPageRange),
-//                              @"AllPages": @(PSPDFDocumentSharingOptionAllPages),
-//                              @"AnnotatedPages": @(PSPDFDocumentSharingOptionAnnotatedPages),
-//                              @"EmbedAnnotations": @(PSPDFDocumentSharingOptionEmbedAnnotations),
-//                              @"FlattenAnnotations": @(PSPDFDocumentSharingOptionFlattenAnnotations),
-//                              @"AnnotationsSummary": @(PSPDFDocumentSharingOptionAnnotationsSummary),
-//                              @"RemoveAnnotations": @(PSPDFDocumentSharingOptionRemoveAnnotations),
-//                              @"FlattenAnnotationsForPrint": @(PSPDFDocumentSharingOptionFlattenAnnotationsForPrint),
-//                              @"OriginalFile": @(PSPDFDocumentSharingOptionOriginalFile),
-//                              @"Image": @(PSPDFDocumentSharingOptionImage)},
+                        //                        @"PSPDFDocumentSharingOptions":
+                        //
+                        //                            @{@"None": @(PSPDFDocumentSharingOptionNone),
+                        //                              @"CurrentPageOnly": @(PSPDFDocumentSharingOptionCurrentPageOnly),
+                        //                              @"PageRange": @(PSPDFDocumentSharingOptionPageRange),
+                        //                              @"AllPages": @(PSPDFDocumentSharingOptionAllPages),
+                        //                              @"AnnotatedPages": @(PSPDFDocumentSharingOptionAnnotatedPages),
+                        //                              @"EmbedAnnotations": @(PSPDFDocumentSharingOptionEmbedAnnotations),
+                        //                              @"FlattenAnnotations": @(PSPDFDocumentSharingOptionFlattenAnnotations),
+                        //                              @"AnnotationsSummary": @(PSPDFDocumentSharingOptionAnnotationsSummary),
+                        //                              @"RemoveAnnotations": @(PSPDFDocumentSharingOptionRemoveAnnotations),
+                        //                              @"FlattenAnnotationsForPrint": @(PSPDFDocumentSharingOptionFlattenAnnotationsForPrint),
+                        //                              @"OriginalFile": @(PSPDFDocumentSharingOptionOriginalFile),
+                        //                              @"Image": @(PSPDFDocumentSharingOptionImage)},
 
                         };
 
@@ -741,27 +700,22 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark PSPDFDocument setters and getters
 
-- (void)setFileURLForPSPDFDocumentWithJSON:(NSString *)path
-{
+- (void)setFileURLForPSPDFDocumentWithJSON:(NSString *)path {
     // Brute-Force-Set.
     [_pdfDocument setValue:[self pdfFileURLWithPath:path] forKey:@"fileURL"];
 }
 
-- (NSString *)fileURLAsJSON
-{
+- (NSString *)fileURLAsJSON {
     return _pdfDocument.fileURL.path;
 }
 
-- (void)setEditableAnnotationTypesForPSPDFViewControllerWithJSON:(NSArray *)types
-{
-    if (![types isKindOfClass:[NSArray class]])
-    {
+- (void)setEditableAnnotationTypesForPSPDFViewControllerWithJSON:(NSArray *)types {
+    if (![types isKindOfClass:[NSArray class]]) {
         types = @[types];
     }
 
     NSMutableSet *qualified = [[NSMutableSet alloc] init];
-    for (NSString *type in types)
-    {
+    for (NSString *type in types) {
         NSString *prefix = @"PSPDFAnnotationType";
         if ([type hasPrefix:prefix]) {
             [qualified addObject:[type substringFromIndex:prefix.length]];
@@ -776,223 +730,186 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     }];
 }
 
-- (void)setDisableAutomaticSavingForPSPDFViewControllerWithJSON:(NSNumber *)shouldDisable
-{
+- (void)setDisableAutomaticSavingForPSPDFViewControllerWithJSON:(NSNumber *)shouldDisable {
     self.disableAutomaticSaving = shouldDisable.boolValue;
 }
 
-- (NSNumber *)disableAutomaticSavingAsJSON
-{
+- (NSNumber *)disableAutomaticSavingAsJSON {
     return @(self.disableAutomaticSaving);
 }
 
-- (NSArray *)editableAnnotationTypesAsJSON
-{
+- (NSArray *)editableAnnotationTypesAsJSON {
     return _pdfController.configuration.editableAnnotationTypes.allObjects;
 }
 
-- (void)setAnnotationSaveModeForPSPDFDocumentWithJSON:(NSString *)option
-{
+- (void)setAnnotationSaveModeForPSPDFDocumentWithJSON:(NSString *)option {
     _pdfDocument.annotationSaveMode = [self enumValueForKey:option ofType:@"PSPDFAnnotationSaveMode" withDefault:PSPDFAnnotationSaveModeEmbeddedWithExternalFileAsFallback];
 }
 
-- (NSString *)annotationSaveModeAsJSON
-{
+- (NSString *)annotationSaveModeAsJSON {
     return [self enumKeyForValue:_pdfDocument.annotationSaveMode ofType:@"PSPDFAnnotationSaveMode"];
 }
 
-- (void)setPageBackgroundColorForPSPDFDocumentWithJSON:(NSString *)color
-{
+- (void)setPageBackgroundColorForPSPDFDocumentWithJSON:(NSString *)color {
     NSMutableDictionary *renderOptions = [[_pdfDocument renderOptionsForType:PSPDFRenderTypeAll context:nil] mutableCopy];
     renderOptions[PSPDFRenderOptionBackgroundFillColorKey] = [self colorWithString:color];
     [_pdfDocument setRenderOptions:renderOptions type:PSPDFRenderTypeAll];
 }
 
-- (NSString *)pageBackgroundColorAsJSON
-{
+- (NSString *)pageBackgroundColorAsJSON {
     NSDictionary *renderOptions = [_pdfDocument renderOptionsForType:PSPDFRenderTypeAll context:nil];
     return [self colorAsString:renderOptions[PSPDFRenderOptionBackgroundFillColorKey]];
 }
 
-- (void)setBackgroundColorForPSPDFDocumentWithJSON:(NSString *)color
-{
+- (void)setBackgroundColorForPSPDFDocumentWithJSON:(NSString *)color {
     //not supported, use pageBackgroundColor instead
 }
 
-- (NSArray *)renderAnnotationTypesAsJSON
-{
+- (NSArray *)renderAnnotationTypesAsJSON {
     NSArray *types = [self optionKeysForValue:_pdfDocument.renderAnnotationTypes ofType:@"PSPDFAnnotationType"];
     return types;
 }
 
-- (void)setRenderAnnotationTypesForPSPDFDocumentWithJSON:(NSArray *)options
-{
+- (void)setRenderAnnotationTypesForPSPDFDocumentWithJSON:(NSArray *)options {
     PSPDFAnnotationType types = (PSPDFAnnotationType) [self optionsValueForKeys:options ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
     _pdfDocument.renderAnnotationTypes = types;
 }
 
 #pragma mark PSPDFViewController setters and getters
 
-- (void)setPageTransitionForPSPDFViewControllerWithJSON:(NSString *)transition
-{
+- (void)setPageTransitionForPSPDFViewControllerWithJSON:(NSString *)transition {
     PSPDFPageTransition pageTransition = (PSPDFPageTransition) [self enumValueForKey:transition ofType:@"PSPDFPageTransition" withDefault:PSPDFPageTransitionScrollPerSpread];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.pageTransition = pageTransition;
     }];
 }
 
-- (NSString *)pageTransitionAsJSON
-{
+- (NSString *)pageTransitionAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.pageTransition ofType:@"PSPDFPageTransition"];
 }
 
-- (void)setViewModeAnimatedForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setViewModeAnimatedForPSPDFViewControllerWithJSON:(NSString *)mode {
     [_pdfController setViewMode:[self enumValueForKey:mode ofType:@"PSPDFViewMode" withDefault:PSPDFViewModeDocument] animated:YES];
 }
 
-- (void)setViewModeForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setViewModeForPSPDFViewControllerWithJSON:(NSString *)mode {
     _pdfController.viewMode = [self enumValueForKey:mode ofType:@"PSPDFViewMode" withDefault:PSPDFViewModeDocument];
 }
 
-- (NSString *)viewModeAsJSON
-{
+- (NSString *)viewModeAsJSON {
     return [self enumKeyForValue:_pdfController.viewMode ofType:@"PSPDFViewMode"];
 }
 
-- (void)setThumbnailBarModeForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setThumbnailBarModeForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFThumbnailBarMode thumbnailBarMode = (PSPDFThumbnailBarMode) [self enumValueForKey:mode ofType:@"PSPDFThumbnailBarMode" withDefault:PSPDFThumbnailBarModeScrubberBar];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.thumbnailBarMode = thumbnailBarMode;
     }];
 }
 
-- (NSString *)thumbnailBarMode
-{
+- (NSString *)thumbnailBarMode {
     return [self enumKeyForValue:_pdfController.configuration.thumbnailBarMode ofType:@"PSPDFThumbnailBarMode"];
 }
 
-- (void)setPageModeForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setPageModeForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFPageMode pageMode = (PSPDFPageMode) [self enumValueForKey:mode ofType:@"PSPDFPageMode" withDefault:PSPDFPageModeAutomatic];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.pageMode = pageMode;
     }];
 }
 
-- (NSString *)pageModeAsJSON
-{
+- (NSString *)pageModeAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.pageMode ofType:@"PSPDFPageMode"];
 }
 
-- (void)setScrollDirectionForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setScrollDirectionForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFScrollDirection scrollDirection = (PSPDFScrollDirection) [self enumValueForKey:mode ofType:@"PSPDFScrollDirection" withDefault:PSPDFScrollDirectionHorizontal];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.scrollDirection = scrollDirection;
     }];
 }
 
-- (NSString *)scrollDirectionAsJSON
-{
+- (NSString *)scrollDirectionAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.scrollDirection ofType:@"PSPDFScrollDirection"];
 }
 
-- (void)setLinkActionForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setLinkActionForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFLinkAction linkAction = (PSPDFLinkAction) [self enumValueForKey:mode ofType:@"PSPDFLinkAction" withDefault:PSPDFLinkActionInlineBrowser];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.linkAction = linkAction;
     }];
 }
 
-- (NSString *)linkActionAsJSON
-{
+- (NSString *)linkActionAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.linkAction ofType:@"PSPDFLinkAction"];
 }
 
-- (void)setUserInterfaceViewModeForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setUserInterfaceViewModeForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFUserInterfaceViewMode userInterfaceViewMode = (PSPDFUserInterfaceViewMode) [self enumValueForKey:mode ofType:@"PSPDFUserInterfaceViewMode" withDefault:PSPDFUserInterfaceViewModeAutomatic];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.userInterfaceViewMode = userInterfaceViewMode;
     }];
 }
 
-- (NSString *)userInterfaceViewModeAsJSON
-{
+- (NSString *)userInterfaceViewModeAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.userInterfaceViewMode ofType:@"PSPDFUserInterfaceViewMode"];
 }
 
-- (void)setUserInterfaceViewAnimationForPSPDFViewControllerWithJSON:(NSString *)mode
-{
+- (void)setUserInterfaceViewAnimationForPSPDFViewControllerWithJSON:(NSString *)mode {
     PSPDFUserInterfaceViewAnimation userInterfaceViewAnimation = (PSPDFUserInterfaceViewAnimation) [self enumValueForKey:mode ofType:@"UserInterfaceViewAnimation" withDefault:PSPDFUserInterfaceViewAnimationFade];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.userInterfaceViewAnimation = userInterfaceViewAnimation;
     }];
 }
 
-- (NSString *)userInterfaceViewAnimationAsJSON
-{
+- (NSString *)userInterfaceViewAnimationAsJSON {
     return [self enumKeyForValue:_pdfController.configuration.userInterfaceViewAnimation ofType:@"PSPDFUserInterfaceViewAnimation"];
 }
 
-- (void)setUserInterfaceVisibleAnimatedForPSPDFViewControllerWithJSON:(NSNumber *)visible
-{
+- (void)setUserInterfaceVisibleAnimatedForPSPDFViewControllerWithJSON:(NSNumber *)visible {
     [_pdfController setUserInterfaceVisible:[visible boolValue] animated:YES];
 }
 
-- (void)setPageAnimatedForPSPDFViewControllerWithJSON:(NSNumber *)page
-{
+- (void)setPageAnimatedForPSPDFViewControllerWithJSON:(NSNumber *)page {
     [_pdfController setPageIndex:[page integerValue] animated:YES];
 }
 
-- (void)setLeftBarButtonItemsForPSPDFViewControllerWithJSON:(NSArray *)items
-{
+- (void)setLeftBarButtonItemsForPSPDFViewControllerWithJSON:(NSArray *)items {
     _pdfController.navigationItem.closeBarButtonItem = nil;
     _pdfController.navigationItem.leftBarButtonItems = [self barButtonItemsWithArray:items] ?: _pdfController.navigationItem.leftBarButtonItems;
 }
 
-- (void)setRightBarButtonItemsForPSPDFViewControllerWithJSON:(NSArray *)items
-{
+- (void)setRightBarButtonItemsForPSPDFViewControllerWithJSON:(NSArray *)items {
     _pdfController.navigationItem.rightBarButtonItems = [self barButtonItemsWithArray:items] ?: _pdfController.navigationItem.rightBarButtonItems;
 }
 
-- (void)setTintColorForPSPDFViewControllerWithJSON:(NSString *)color
-{
+- (void)setTintColorForPSPDFViewControllerWithJSON:(NSString *)color {
     _pdfController.view.tintColor = [self colorWithString:color];
 }
 
-- (NSString *)tintColorAsJSON
-{
+- (NSString *)tintColorAsJSON {
     return [self colorAsString:_pdfController.view.tintColor];
 }
 
-- (void)setBackgroundColorForPSPDFViewControllerWithJSON:(NSString *)color
-{
+- (void)setBackgroundColorForPSPDFViewControllerWithJSON:(NSString *)color {
     UIColor *backgroundColor = [self colorWithString:color];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.backgroundColor = backgroundColor;
     }];
 }
 
-- (NSString *)backgroundColorAsJSON
-{
+- (NSString *)backgroundColorAsJSON {
     return [self colorAsString:_pdfController.configuration.backgroundColor];
 }
 
-- (void)setAllowedMenuActionsForPSPDFViewControllerWithJSON:(NSArray *)options
-{
+- (void)setAllowedMenuActionsForPSPDFViewControllerWithJSON:(NSArray *)options {
     PSPDFTextSelectionMenuAction menuActions = (PSPDFTextSelectionMenuAction) [self optionsValueForKeys:options ofType:@"PSPDFTextSelectionMenuAction" withDefault:PSPDFTextSelectionMenuActionAll];
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.allowedMenuActions = menuActions;
     }];
 }
 
-- (NSArray *)allowedMenuActionsAsJSON
-{
+- (NSArray *)allowedMenuActionsAsJSON {
     return [self optionKeysForValue:_pdfController.configuration.allowedMenuActions ofType:@"PSPDFTextSelectionMenuAction"];
 }
 
@@ -1022,58 +939,49 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 //    return @(_pdfController.configuration.printSharingOptions);
 //}
 
-- (void)setShouldAskForAnnotationUsernameForPSPDFViewControllerWithJSON:(NSNumber *)shouldAskForAnnotationUsername
-{
+- (void)setShouldAskForAnnotationUsernameForPSPDFViewControllerWithJSON:(NSNumber *)shouldAskForAnnotationUsername {
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.shouldAskForAnnotationUsername = shouldAskForAnnotationUsername.boolValue;
     }];
 }
 
-- (NSNumber *)shouldAskForAnnotationUsernameAsJSON
-{
+- (NSNumber *)shouldAskForAnnotationUsernameAsJSON {
     return @(_pdfController.configuration.shouldAskForAnnotationUsername);
 }
 
-- (void)setPageGrabberEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageGrabberEnabled
-{
+- (void)setPageGrabberEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageGrabberEnabled {
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.pageGrabberEnabled = pageGrabberEnabled.boolValue;
     }];
 }
 
-- (NSNumber *)pageGrabberEnabledAsJSON
-{
+- (NSNumber *)pageGrabberEnabledAsJSON {
     return @(_pdfController.configuration.pageGrabberEnabled);
 }
 
-- (void)setPageLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageLabelEnabled
-{
+- (void)setPageLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageLabelEnabled {
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.pageLabelEnabled = pageLabelEnabled.boolValue;
     }];
 }
 
-- (NSNumber *)pageLabelEnabledAsJSON
-{
+- (NSNumber *)pageLabelEnabledAsJSON {
     return @(_pdfController.configuration.pageLabelEnabled);
 }
 
-- (void)setDocumentLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)documentLabelEnabled
-{
+- (void)setDocumentLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)documentLabelEnabled {
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.documentLabelEnabled = documentLabelEnabled.boolValue;
     }];
 }
 
-- (NSNumber *)documentLabelEnabledAsJSON
-{
+- (NSNumber *)documentLabelEnabledAsJSON {
     return @(_pdfController.configuration.documentLabelEnabled);
 }
 
 #pragma mark PDFProcessing methods
 
-- (void)convertPDFFromHTMLString:(CDVInvokedUrlCommand *)command
-{
+- (void)convertPDFFromHTMLString:(CDVInvokedUrlCommand *)command {
     NSString *decodeHTMLString = [[[command argumentAtIndex:0] stringByReplacingOccurrencesOfString:@"+" withString:@""]stringByRemovingPercentEncoding];
     NSString *fileName = [command argumentAtIndex:1 withDefault:@"Sample"];
     NSDictionary *options = [command argumentAtIndex:2 withDefault:nil];
@@ -1082,14 +990,10 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
     void (^completionBlock)(NSError *error) = ^(NSError *error) {
         CDVPluginResult *pluginResult;
-
-        if (error)
-        {
+        if (error) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                          messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
-        }
-        else
-        {
+        } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                          messageAsDictionary:@{@"filePath":outputFilePath}];
         }
@@ -1100,8 +1004,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     [self generatePDFFromHTMLString:decodeHTMLString outputFile:outputFilePath options:options completionBlock:completionBlock];
 }
 
-- (void)generatePDFFromHTMLString:(NSString *)html outputFile:(NSString *)filePath options:(NSDictionary *)options completionBlock:(void (^)(NSError *error))completionBlock
-{
+- (void)generatePDFFromHTMLString:(NSString *)html outputFile:(NSString *)filePath options:(NSDictionary *)options completionBlock:(void (^)(NSError *error))completionBlock {
     PSPDFProcessor *processor = [[PSPDFProcessor alloc] initWithOptions:nil];
     [processor convertHTMLString:html outputFileURL:[NSURL fileURLWithPath:filePath] completionBlock:completionBlock];
 }
@@ -1164,15 +1067,13 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                         callbackId:command.callbackId];
         }];
-    }
-    else {
+    } else {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
                                     callbackId:command.callbackId];
     }
 }
 
-- (void)dismiss:(CDVInvokedUrlCommand *)command
-{
+- (void)dismiss:(CDVInvokedUrlCommand *)command {
     [_navigationController.presentingViewController dismissViewControllerAnimated:YES completion:^{
 
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
@@ -1180,15 +1081,13 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     }];
 }
 
-- (void)reload:(CDVInvokedUrlCommand *)command
-{
+- (void)reload:(CDVInvokedUrlCommand *)command {
     [_pdfController reloadData];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                 callbackId:command.callbackId];
 }
 
-- (void)search:(CDVInvokedUrlCommand *)command
-{
+- (void)search:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *pluginResult = nil;
     NSString *query = [command argumentAtIndex:0];
     BOOL animated = [[command argumentAtIndex:1 withDefault:@NO] boolValue];
@@ -1197,8 +1096,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     if (query) {
         [_pdfController searchForString:query options:@{PSPDFViewControllerSearchHeadlessKey: @(headless)} sender:nil animated:animated];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    }
-    else {
+    } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                          messageAsString:@"'query' argument was null"];
     }
@@ -1207,23 +1105,20 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                                 callbackId:command.callbackId];
 }
 
-- (void)saveAnnotations:(CDVInvokedUrlCommand *)command
-{
+- (void)saveAnnotations:(CDVInvokedUrlCommand *)command {
     // Completion handler is called on the main queue
     [_pdfController.document saveWithOptions:nil completionHandler:^(NSError * _Nullable error, NSArray<__kindof PSPDFAnnotation *> * _Nonnull savedAnnotations) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self dictionaryWithError:error]] callbackId:command.callbackId];
     }];
 }
 
-- (void)getHasDirtyAnnotations:(CDVInvokedUrlCommand *)command
-{
+- (void)getHasDirtyAnnotations:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:_pdfDocument.hasDirtyAnnotations] callbackId:command.callbackId];
 }
 
 #pragma mark Configuration
 
-- (void)setOptions:(CDVInvokedUrlCommand *)command
-{
+- (void)setOptions:(CDVInvokedUrlCommand *)command {
     NSDictionary *options = [command argumentAtIndex:0];
     BOOL animated = [[command argumentAtIndex:1 withDefault:@NO] boolValue];
     [self setOptionsWithDictionary:options animated:animated];
@@ -1231,8 +1126,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                                 callbackId:command.callbackId];
 }
 
-- (void)setOption:(CDVInvokedUrlCommand *)command
-{
+- (void)setOption:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *pluginResult = nil;
     NSString *key = [command argumentAtIndex:0];
     id value = [command argumentAtIndex:1];
@@ -1241,8 +1135,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     if (key && value) {
         [self setOptionsWithDictionary:@{key: value} animated:animated];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    }
-    else {
+    } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                          messageAsString:@"'key' and/or 'value' argument was null"];
     }
@@ -1251,8 +1144,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                                 callbackId:command.callbackId];
 }
 
-- (void)getOptions:(CDVInvokedUrlCommand *)command
-{
+- (void)getOptions:(CDVInvokedUrlCommand *)command {
     NSMutableDictionary *values = [NSMutableDictionary dictionary];
     NSArray *names = [command argumentAtIndex:0];
     for (NSString *name in names) {
@@ -1263,11 +1155,9 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:values] callbackId:command.callbackId];
 }
 
-- (void)getOption:(CDVInvokedUrlCommand *)command
-{
+- (void)getOption:(CDVInvokedUrlCommand *)command {
     NSString *key = [command argumentAtIndex:0];
-    if (key)
-    {
+    if (key) {
         id value = [self optionAsJSON:key];
 
         //determine type
@@ -1314,8 +1204,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark Paging
 
-- (void)setPage:(CDVInvokedUrlCommand *)command
-{
+- (void)setPage:(CDVInvokedUrlCommand *)command {
     NSInteger page = [[command argumentAtIndex:0 withDefault:@(NSNotFound)] integerValue];
     BOOL animated = [[command argumentAtIndex:1 withDefault:@NO] boolValue];
 
@@ -1323,32 +1212,27 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
         [_pdfController setPageIndex:page animated:animated];
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                     callbackId:command.callbackId];
-    }
-    else {
+    } else {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"'page' argument was null"] callbackId:command.callbackId];
     }
 }
 
-- (void)getPage:(CDVInvokedUrlCommand *)command
-{
+- (void)getPage:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)_pdfController.pageIndex] callbackId:command.callbackId];
 }
 
-- (void)getPageCount:(CDVInvokedUrlCommand *)command
-{
+- (void)getPageCount:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)_pdfDocument.pageCount] callbackId:command.callbackId];
 }
 
-- (void)scrollToNextPage:(CDVInvokedUrlCommand *)command
-{
+- (void)scrollToNextPage:(CDVInvokedUrlCommand *)command {
     BOOL animated = [[command argumentAtIndex:0 withDefault:@NO] boolValue];
     [_pdfController.documentViewController scrollToNextSpreadAnimated:animated];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                 callbackId:command.callbackId];
 }
 
-- (void)scrollToPreviousPage:(CDVInvokedUrlCommand *)command
-{
+- (void)scrollToPreviousPage:(CDVInvokedUrlCommand *)command {
     BOOL animated = [[command argumentAtIndex:0 withDefault:@NO] boolValue];
     [_pdfController.documentViewController scrollToNextSpreadAnimated:animated];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
@@ -1357,16 +1241,14 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark Toolbar Items
 
-- (void)setLeftBarButtonItems:(CDVInvokedUrlCommand *)command
-{
+- (void)setLeftBarButtonItems:(CDVInvokedUrlCommand *)command {
     NSArray *items = [command argumentAtIndex:0 withDefault:@[]];
     [self setOptionsWithDictionary:@{@"leftBarButtonItems": items} animated:NO];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                 callbackId:command.callbackId];
 }
 
-- (void)setRightBarButtonItems:(CDVInvokedUrlCommand *)command
-{
+- (void)setRightBarButtonItems:(CDVInvokedUrlCommand *)command {
     NSArray *items = [command argumentAtIndex:0 withDefault:@[]];
     [self setOptionsWithDictionary:@{@"rightBarButtonItems": items} animated:NO];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
@@ -1375,16 +1257,14 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark Annotation Toolbar methods
 
-- (void)hideAnnotationToolbar:(CDVInvokedUrlCommand *)command
-{
+- (void)hideAnnotationToolbar:(CDVInvokedUrlCommand *)command {
     [_pdfController.annotationToolbarController updateHostView:nil container:nil viewController:_pdfController];
     [_pdfController.annotationToolbarController hideToolbarAnimated:YES];
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                 callbackId:command.callbackId];
 }
 
-- (void)showAnnotationToolbar:(CDVInvokedUrlCommand *)command
-{
+- (void)showAnnotationToolbar:(CDVInvokedUrlCommand *)command {
     // Must be in document view mode when showing annotation toolbar
     [_pdfController setViewMode:PSPDFViewModeDocument animated:YES];
 
@@ -1394,8 +1274,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
                                 callbackId:command.callbackId];
 }
 
-- (void)toggleAnnotationToolbar:(CDVInvokedUrlCommand *)command
-{
+- (void)toggleAnnotationToolbar:(CDVInvokedUrlCommand *)command {
     // Must be in document view mode when showing annotation toolbar
     [_pdfController setViewMode:PSPDFViewModeDocument animated:YES];
 
@@ -1407,40 +1286,33 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void))
 
 #pragma mark Delegate methods
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSaveDocument:(nonnull PSPDFDocument *)document withOptions:(NSDictionary<PSPDFDocumentSaveOption,id> *__autoreleasing  _Nonnull * _Nonnull)options
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSaveDocument:(nonnull PSPDFDocument *)document withOptions:(NSDictionary<PSPDFDocumentSaveOption,id> *__autoreleasing  _Nonnull * _Nonnull)options {
     return !self.disableAutomaticSaving;
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {
     [self sendEventWithJSON:[NSString stringWithFormat:@"{type:'willBeginDisplayingPageView',page:%ld}", (long) pageIndex]];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didFinishRenderTaskForPageView:(PSPDFPageView *)pageView
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didFinishRenderTaskForPageView:(PSPDFPageView *)pageView {
     [self sendEventWithJSON:[NSString stringWithFormat:@"{type:'didFinishRenderTaskForPageView',page:%ld}", (long) pageView.pageIndex]];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didConfigurePageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didConfigurePageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {
     [self sendEventWithJSON:[NSString stringWithFormat:@"{type:'didConfigurePageView',page:%ld}", (long) pageView.pageIndex]];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didCleanupPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didCleanupPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {
     [self sendEventWithJSON:[NSString stringWithFormat:@"{type:'didCleanupPageView',page:%ld}", (long) pageView.pageIndex]];
 }
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController didTapOnPageView:(PSPDFPageView *)pageView atPoint:(CGPoint)viewPoint
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController didTapOnPageView:(PSPDFPageView *)pageView atPoint:(CGPoint)viewPoint {
     // inverted because it's almost always YES (due to handling JS eval calls).
     // in order to set this event as handled use explicit "return false;" in JS callback.
     return ![self sendEventWithJSON:[NSString stringWithFormat:@"{type:'didTapOnPageView',viewPoint:[%g,%g]}", viewPoint.x, viewPoint.y]];
 }
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController didLongPressOnPageView:(PSPDFPageView *)pageView atPoint:(CGPoint)viewPoint gestureRecognizer:(UILongPressGestureRecognizer *)gestureRecognizer
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController didLongPressOnPageView:(PSPDFPageView *)pageView atPoint:(CGPoint)viewPoint gestureRecognizer:(UILongPressGestureRecognizer *)gestureRecognizer {
     // inverted because it's almost always YES (due to handling JS eval calls).
     // in order to set this event as handled use explicit "return false;" in JS callback.
     return ![self sendEventWithJSON:[NSString stringWithFormat:@"{type:'didLongPressOnPageView',viewPoint:[%g,%g]}", viewPoint.x, viewPoint.y]];
@@ -1450,23 +1322,19 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     return [NSString stringWithFormat:@"[%g,%g,%g,%g]", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height];
 }
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSelectText:(NSString *)text withGlyphs:(NSArray *)glyphs atRect:(CGRect)rect onPageView:(PSPDFPageView *)pageView
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSelectText:(NSString *)text withGlyphs:(NSArray *)glyphs atRect:(CGRect)rect onPageView:(PSPDFPageView *)pageView {
     return [self sendEventWithJSON:@{@"type": @"shouldSelectText", @"text": text, @"rect": PSPDFStringFromCGRect(rect)}];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didSelectText:(NSString *)text withGlyphs:(NSArray *)glyphs atRect:(CGRect)rect onPageView:(PSPDFPageView *)pageView
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didSelectText:(NSString *)text withGlyphs:(NSArray *)glyphs atRect:(CGRect)rect onPageView:(PSPDFPageView *)pageView {
     [self sendEventWithJSON:@{@"type": @"didSelectText", @"text": text, @"rect": PSPDFStringFromCGRect(rect)}];
 }
 
-- (void)pdfViewControllerWillDismiss:(PSPDFViewController *)pdfController
-{
+- (void)pdfViewControllerWillDismiss:(PSPDFViewController *)pdfController {
     [self sendEventWithJSON:@"{type:'willDismiss'}"];
 }
 
-- (void)pdfViewControllerDidDismiss:(PSPDFViewController *)pdfController
-{
+- (void)pdfViewControllerDidDismiss:(PSPDFViewController *)pdfController {
     //release the pdf document and controller
     _pdfDocument = nil;
     _pdfController = nil;
@@ -1476,23 +1344,19 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     [self sendEventWithJSON:@"{type:'didDismiss'}"];
 }
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldShowUserInterface:(BOOL)animated
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldShowUserInterface:(BOOL)animated {
     return [self sendEventWithJSON:@{@"type": @"shouldShowUserInterface", @"animated": @(animated)}];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didShowUserInterface:(BOOL)animated
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didShowUserInterface:(BOOL)animated {
     [self sendEventWithJSON:@{@"type": @"didShowUserInterface", @"animated": @(animated)}];
 }
 
-- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldHideUserInterface:(BOOL)animated
-{
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldHideUserInterface:(BOOL)animated {
     return [self sendEventWithJSON:@{@"type": @"shouldHideUserInterface", @"animated": @(animated)}];
 }
 
-- (void)pdfViewController:(PSPDFViewController *)pdfController didHideUserInterface:(BOOL)animated
-{
+- (void)pdfViewController:(PSPDFViewController *)pdfController didHideUserInterface:(BOOL)animated {
     [self sendEventWithJSON:@{@"type": @"didHideUserInterface", @"animated": @(animated)}];
 }
 

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -416,7 +416,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     if (![NSFileManager.defaultManager fileExistsAtPath:(NSString *)xfdfFileURL.path]) {
         // Create the folder where the XFDF file will be saved.
         NSError *createFolderError;
-        if (![[NSFileManager defaultManager] createDirectoryAtPath:[xfdfFileURL.path stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
+        if (![NSFileManager.defaultManager createDirectoryAtPath:xfdfFileURL.path.stringByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
             NSLog(@"Failed to create directory: %@", createFolderError.localizedDescription);
             return;
         }

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -187,5 +187,14 @@ var PSPDFKitPlugin = new function() {
         toggleAnnotationToolbar: [],
     });
     
+    //Instant JSON
+    addMethods({
+        addAnnotations: ['jsonAnnotations', 'callback'],
+        addAnnotation: ['jsonAnnotation', 'callback'],
+        removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+        getAnnotations: ['pageIndex', 'type', 'callback'],
+        getAllUnsavedAnnotations: ['callback']
+    });
+    
 };
 module.exports = PSPDFKitPlugin;

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -100,7 +100,8 @@ var PSPDFKitPlugin = new function() {
     // Document methods
     
     addMethods({
-        present: ['path', 'callback', 'options', 'xfdfPath'],
+        present: ['path', 'callback', 'options'],
+        presentWithXFDF: ['path', 'xfdfPath', 'callback', 'options'],
         dismiss: ['callback'],
         reload: [],
         search: ['query', 'animated', 'headless'],

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -100,7 +100,7 @@ var PSPDFKitPlugin = new function() {
     //document methods
     
     addMethods({
-        present: ['path', 'callback', 'options'],
+        present: ['path', 'callback', 'options', 'xfdfPath'],
         dismiss: ['callback'],
         reload: [],
         search: ['query', 'animated', 'headless'],

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -2,7 +2,7 @@
 //  PSPDFKit.h
 //  PSPDFPlugin for Apache Cordova
 //
-//  Copyright © 2013-2018 PSPDFKit GmbH. All rights reserved.
+//  Copyright © 2013-2019 PSPDFKit GmbH. All rights reserved.
 //
 //  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY AUSTRIAN COPYRIGHT LAW
 //  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
@@ -12,7 +12,7 @@
 
 var PSPDFKitPlugin = new function() {
     
-    //utilities
+    // Utilities
     
     var self = this;
     function addMethods(methods) {
@@ -41,7 +41,7 @@ var PSPDFKitPlugin = new function() {
         }
     }
     
-    //events
+    // Events
     
     var listeners = {};
     
@@ -85,19 +85,19 @@ var PSPDFKitPlugin = new function() {
         }
     }
 
-    //license key
+    // License key
     
     addMethods({
         setLicenseKey: ['key'],
     });
 
-    //PDF Generation method
+    // PDF Generation method
     
     addMethods({
         convertPDFFromHTMLString: ['html', 'fileName', 'options', 'callback'],
     });
     
-    //document methods
+    // Document methods
     
     addMethods({
         present: ['path', 'callback', 'options', 'xfdfPath'],
@@ -108,7 +108,7 @@ var PSPDFKitPlugin = new function() {
         getHasDirtyAnnotations: ['callback'],
     });
     
-    //configuration
+    // Configuration
     
     addMethods({
         setOptions: ['options', 'animated'],
@@ -117,7 +117,7 @@ var PSPDFKitPlugin = new function() {
         getOption: ['name', 'callback'],
     });
     
-    //page scrolling
+    // Page scrolling
     
     addMethods({
         setPage: ['page', 'animated'],
@@ -128,20 +128,20 @@ var PSPDFKitPlugin = new function() {
         scrollToPreviousPage: ['animated'],
     });
 
-    //appearance
+    // Appearance
     
     addMethods({
         setAppearanceMode: ['appearanceMode'],
     });
 
-    //cache
+    // Cache
 
     addMethods({
         clearCache: [],
         removeCacheForPresentedDocument: [],
     });
 
-    //toolbar
+    // Toolbar
     
     var leftBarButtonItems = ['close'];
     var rightBarButtonItems = ['search', 'outline', 'thumbnails'];
@@ -180,14 +180,14 @@ var PSPDFKitPlugin = new function() {
         callback(rightBarButtonItems);
     }
 
-    //annotation toolbar
+    // Annotation toolbar
     addMethods({
         hideAnnotationToolbar: [],
         showAnnotationToolbar: [],
         toggleAnnotationToolbar: [],
     });
     
-    //Instant JSON
+    // Instant JSON
     addMethods({
         addAnnotations: ['jsonAnnotations', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
@@ -196,7 +196,7 @@ var PSPDFKitPlugin = new function() {
         getAllUnsavedAnnotations: ['callback']
     });
     
-    //Forms
+    // Forms
     addMethods({
         setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
         getFormFieldValue: ['fullyQualifiedName', 'callback'],

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -191,7 +191,7 @@ var PSPDFKitPlugin = new function() {
     addMethods({
         addAnnotations: ['jsonAnnotations', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
-        removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+        removeAnnotation: ['jsonAnnotation', 'callback'],
         getAnnotations: ['pageIndex', 'type', 'callback'],
         getAllUnsavedAnnotations: ['callback']
     });

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -190,7 +190,7 @@ var PSPDFKitPlugin = new function() {
     
     // Instant JSON
     addMethods({
-        addAnnotations: ['jsonAnnotations', 'callback'],
+        applyInstantJSON: ['jsonValue', 'callback'],
         addAnnotation: ['jsonAnnotation', 'callback'],
         removeAnnotation: ['jsonAnnotation', 'callback'],
         getAnnotations: ['pageIndex', 'type', 'callback'],

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -196,5 +196,11 @@ var PSPDFKitPlugin = new function() {
         getAllUnsavedAnnotations: ['callback']
     });
     
+    //Forms
+    addMethods({
+        setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
+        getFormFieldValue: ['fullyQualifiedName', 'callback'],
+    });
+    
 };
 module.exports = PSPDFKitPlugin;

--- a/README.md
+++ b/README.md
@@ -405,8 +405,9 @@ Annotation API
 
 The methods below allows you to programmatically access, add, and remove annotations using the Instant JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/
 
-    // Add multiple annotations using an Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
-    addAnnotations(jsonAnnotations, [callback]);
+    // Apply Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
+    // Can be used to add annotations, bookmarks, fill forms, etc.
+    applyInstantJSON(jsonValue, [callback]);
 
     // Add a single annotation using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
     addAnnotation(jsonAnnotation, [callback]);

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Functions
 
 The plugin functions currently implemented are:
 
-    present(path, [callback], [options], xfdfPath);
+    present(path, [callback], [options]);
     
 Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
 
@@ -137,7 +137,15 @@ The options parameter is an optional object containing configuration properties 
 
 The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
 
-The xfdfPath parameter is an optional string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in '"~/Documents/" + xfdfPath'). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/myXFDF.xfdf" or "~/Library/Application Support/myXFDF.xfdf". The xfdfPath can be omitted.
+    presentWithXFDF(path, xfdfPath,[callback], [options]);
+
+Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
+
+The xfdfPath should be a  string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in '"~/Documents/" + xfdfPath'). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/myXFDF.xfdf" or "~/Library/Application Support/myXFDF.xfdf". The xfdfPath cannot be null and must not be omitted.
+
+The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
+
+The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
 
     dismiss([callback]);
     

--- a/README.md
+++ b/README.md
@@ -129,13 +129,15 @@ Functions
 
 The plugin functions currently implemented are:
 
-    present(path, [callback], [options]);
+    present(path, [callback], [options], xfdfPath);
     
-Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the page has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
+Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
 
 The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
 
 The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
+
+The xfdfPath parameter is an optional string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in '"~/Documents/" + xfdfPath'). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/myXFDF.xfdf" or "~/Library/Application Support/myXFDF.xfdf". The xfdfPath can be omitted.
 
     dismiss([callback]);
     
@@ -390,7 +392,39 @@ The following events are supported by the PSPDFKitPlugin class
     flexibleToolbarContainerDidShow
     flexibleToolbarContainerDidHide
 
+Annotation API
+---------------
 
+
+The methods below allows you to programmatically access, add, and remove annnotations using the Instant JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/
+
+    // Add multiple annotations using an Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
+    addAnnotations: ['jsonAnnotations', 'callback'],
+
+    // Add a single annotations using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+    addAnnotation: ['jsonAnnotation', 'callback'],
+
+    // Remove an annotation by UUID.
+    removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+    
+    // Get all the annotations at the specified page index by type.
+    getAnnotations: ['pageIndex', 'type', 'callback'],
+    
+    // Get all unsaved annotations.
+    getAllUnsavedAnnotations: ['callback']
+
+    
+Forms API
+---------------
+
+The following methods allow you to programmatically fill forms and get the value of a form field.
+
+    // Sets the form field value by specifying its fully qualified name.
+    setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
+    
+    // Gets the form field value by specifying its fully qualified name.
+    getFormFieldValue: ['fullyQualifiedName', 'callback'],
+    
 License
 ------------
 

--- a/README.md
+++ b/README.md
@@ -403,23 +403,22 @@ The following events are supported by the PSPDFKitPlugin class
 Annotation API
 ---------------
 
-
 The methods below allows you to programmatically access, add, and remove annotations using the Instant JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/
 
     // Add multiple annotations using an Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
-    addAnnotations: ['jsonAnnotations', 'callback'],
+    addAnnotations(jsonAnnotations, [callback]);
 
     // Add a single annotation using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
-    addAnnotation: ['jsonAnnotation', 'callback'],
+    addAnnotation(jsonAnnotation, [callback]);
 
     // Remove an annotation.
-    removeAnnotation: ['jsonAnnotation', 'callback'],
+    removeAnnotation(jsonAnnotation, [callback]);
     
     // Get all the annotations at the specified page index by type.
-    getAnnotations: ['pageIndex', 'type', 'callback'],
+    getAnnotations(pageIndex, type, [callback]);
     
     // Get all unsaved annotations.
-    getAllUnsavedAnnotations: ['callback']
+    getAllUnsavedAnnotations(callback(value));
 
     
 Forms API
@@ -428,10 +427,10 @@ Forms API
 The following methods allow you to programmatically fill forms and get the value of a form field.
 
     // Sets the form field value by specifying its fully qualified name.
-    setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
+    setFormFieldValue(value, fullyQualifiedName, [callback]);
     
     // Gets the form field value by specifying its fully qualified name.
-    getFormFieldValue: ['fullyQualifiedName', 'callback'],
+    getFormFieldValue(fullyQualifiedName, callback(value));
     
 License
 ------------

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Annotation API
 ---------------
 
 
-The methods below allows you to programmatically access, add, and remove annnotations using the Instant JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/
+The methods below allows you to programmatically access, add, and remove annotations using the Instant JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/
 
     // Add multiple annotations using an Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
     addAnnotations: ['jsonAnnotations', 'callback'],

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The methods below allows you to programmatically access, add, and remove annotat
     // Add multiple annotations using an Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
     addAnnotations: ['jsonAnnotations', 'callback'],
 
-    // Add a single annotations using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+    // Add a single annotation using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
     addAnnotation: ['jsonAnnotation', 'callback'],
 
     // Remove an annotation.

--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ The methods below allows you to programmatically access, add, and remove annnota
     // Add a single annotations using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
     addAnnotation: ['jsonAnnotation', 'callback'],
 
-    // Remove an annotation by UUID.
-    removeAnnotationWithUUID: ['annotationUUID', 'callback'],
+    // Remove an annotation.
+    removeAnnotation: ['jsonAnnotation', 'callback'],
     
     // Get all the annotations at the specified page index by type.
     getAnnotations: ['pageIndex', 'type', 'callback'],

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The options parameter is an optional object containing configuration properties 
 
 The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
 
-    presentWithXFDF(path, xfdfPath,[callback], [options]);
+    presentWithXFDF(path, xfdfPath, [callback], [options]);
 
 Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.2.7" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.2.8" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>


### PR DESCRIPTION
Fixes #57, #74 

---

- [x] Adds Instant JSON API to programmatically manipulate annotations.
- [x] Adds form filling API.
- [x] Adds XFDF support.

Newly added Javascript API: https://github.com/PSPDFKit/Cordova-iOS/pull/75/files#diff-fb148416a3be735793ee250cd3ab0fe3

Sorry for the huge diff in `PSPDFKitPlugin.m`. Most of it is formatting. The notable changes are here:

- https://github.com/PSPDFKit/Cordova-iOS/pull/75/files#diff-912835c7ca24f9549c00325f8235dbbbR1050
- https://github.com/PSPDFKit/Cordova-iOS/pull/75/files#diff-912835c7ca24f9549c00325f8235dbbbR398
- https://github.com/PSPDFKit/Cordova-iOS/pull/75/files#diff-912835c7ca24f9549c00325f8235dbbbR1376