### PR TITLE
Appropriately convert colors with 0 alpha to UIColor.clearColor

### DIFF
--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -186,6 +186,12 @@
         if ([components count] > 3) {
             alpha = [[components[3] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] floatValue];
         }
+
+        // Return clear color if the alpha of the value supplied is 0.
+        if (alpha == 0) {
+            return [UIColor clearColor];
+        }
+
         if ([components count] > 2) {
             NSString *red = [components[0] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
             NSString *green = [components[1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -188,6 +188,7 @@
         }
 
         // Return clear color if the alpha of the value supplied is 0.
+        // We internally check for clearColor when saving colors for the last used color. See #20042
         if (alpha == 0) {
             return [UIColor clearColor];
         }


### PR DESCRIPTION
Using a UIColor object in RGB color space for clear color can be problematic hence this adds a change to convert colors with 0 alpha to the `UIColor.clearColor` object.

Related to 19896.