### PR TITLE
Add the ability to import and export from/to an XFDF file

### DIFF
--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -203,6 +203,12 @@ var PSPDFKitPlugin = new function() {
         setFormFieldValue: ['value', 'fullyQualifiedName', 'callback'],
         getFormFieldValue: ['fullyQualifiedName', 'callback'],
     });
+	
+    // XFDF
+    addMethods({
+        importXFDF: ['xfdfPath', 'callback'],
+        exportXFDF: ['xfdfPath', 'callback'],
+    });
 };
 module.exports = PSPDFKitPlugin;
 

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -385,7 +385,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     }
 }
 
-- (NSURL *)pdfFileURLWithPath:(NSString *)path {
+- (NSURL *)fileURLWithPath:(NSString *)path {
     if (path) {
         path = [path stringByExpandingTildeInPath];
         path = [path stringByReplacingOccurrencesOfString:@"file:" withString:@""];
@@ -395,6 +395,37 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
         return [NSURL fileURLWithPath:path];
     }
     return nil;
+}
+
+- (NSURL *)writableFileURLWithPath:(NSString *)path override:(BOOL)override copyIfNeeded:(BOOL)copyIfNeeded {
+    NSString *docsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    NSURL *writableFileURL = [NSURL fileURLWithPath:[docsFolder stringByAppendingPathComponent:path]];
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    if (override) {
+        [fileManager removeItemAtURL:writableFileURL error:NULL];
+    }
+
+    // If we don't have a writable file already, we move the provided file to the ~/Documents folder.
+    if (![fileManager fileExistsAtPath:(NSString *)writableFileURL.path]) {
+        // Create the folder where the wirtable file will be saved.
+        NSError *createFolderError;
+        if (![fileManager createDirectoryAtPath:writableFileURL.path.stringByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
+            NSLog(@"Failed to create directory: %@", createFolderError.localizedDescription);
+            return nil;
+        }
+
+        // Copy the provided file to a writable location if it exists.
+        NSURL *fileURL = [self fileURLWithPath:path];
+        NSError *copyError;
+        if (copyIfNeeded && [fileManager fileExistsAtPath:(NSString *)fileURL.path]) {
+            if (![fileManager copyItemAtURL:fileURL toURL:writableFileURL error:&copyError]) {
+                NSLog(@"Failed to copy item at URL '%@' with error: %@", path, copyError.localizedDescription);
+                return nil;
+            }
+        }
+    }
+    return writableFileURL;
 }
 
 - (BOOL)isImagePath:(NSString *)path {
@@ -409,7 +440,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
     if (path) {
         //configure document
-        NSURL *url = [self pdfFileURLWithPath:path];
+        NSURL *url = [self fileURLWithPath:path];
         if ([self isImagePath:path]) {
             _pdfDocument = [[PSPDFImageDocument alloc] initWithImageURL:url];
         }
@@ -435,25 +466,11 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 }
 
 - (PSPDFDocument *)createXFDFDocumentWithPath:(NSString *)xfdfFilePath {
-    NSURL *xfdfFileURL;
-    if (xfdfFilePath.isAbsolutePath) {
-        xfdfFileURL = [self pdfFileURLWithPath:xfdfFilePath];
-    } else {
-        // Locate the XFDF file in the ~/Documents directory
-        NSString *docsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
-        xfdfFileURL = [NSURL fileURLWithPath:[docsFolder stringByAppendingPathComponent:xfdfFilePath]];
-    }
+    // Copy the XFDF file to the ~/Documents foler or create one if we don't have one.
+    NSURL *xfdfFileURL = [self writableFileURLWithPath:xfdfFilePath override:NO copyIfNeeded:YES];
 
     // Create an XFDF file from the current document if one doesn't already exist.
     if (![NSFileManager.defaultManager fileExistsAtPath:(NSString *)xfdfFileURL.path]) {
-        // Create the folder where the XFDF file will be saved.
-        NSError *createFolderError;
-        if (![NSFileManager.defaultManager createDirectoryAtPath:xfdfFileURL.path.stringByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
-            NSLog(@"Failed to create directory: %@", createFolderError.localizedDescription);
-            return nil;
-        }
-
-        // Write the file
         NSError *error;
         PSPDFFileDataSink *dataSink = [[PSPDFFileDataSink alloc] initWithFileURL:xfdfFileURL options:PSPDFDataSinkOptionNone error:&error];
         if (dataSink) {
@@ -729,7 +746,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
 - (void)setFileURLForPSPDFDocumentWithJSON:(NSString *)path {
     // Brute-Force-Set.
-    [_pdfDocument setValue:[self pdfFileURLWithPath:path] forKey:@"fileURL"];
+    [_pdfDocument setValue:[self fileURLWithPath:path] forKey:@"fileURL"];
 }
 
 - (NSString *)fileURLAsJSON {
@@ -1063,9 +1080,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
     // Validate the XFDF file path.
     if (xfdfFilePath.length == 0) {
-        NSLog(@"The XFDF path must be a valid string");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The XFDF path must be a valid string."] callbackId:command.callbackId];
         return;
     }
 
@@ -1427,9 +1442,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     } else if ([jsonAnnotation isKindOfClass:NSDictionary.class])  {
         data = [NSJSONSerialization dataWithJSONObject:jsonAnnotation options:0 error:nil];
     } else {
-        NSLog(@"Invalid JSON Annotation.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid JSON Annotation."] callbackId:command.callbackId];
         return;
     }
 
@@ -1447,9 +1460,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                     callbackId:command.callbackId];
     } else {
-        NSLog(@"Failed to add annotation.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to add annotation."] callbackId:command.callbackId];
     }
 }
 
@@ -1457,9 +1468,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     id jsonAnnotation = [command argumentAtIndex:0];
     NSString *annotationUUID = jsonAnnotation[@"uuid"];
     if (annotationUUID.length == 0) {
-        NSLog(@"Invalid annotation UUID.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid annotation UUID."] callbackId:command.callbackId];
     }
     
     PSPDFDocument *document = self.pdfController.document;
@@ -1479,9 +1488,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                     callbackId:command.callbackId];
     } else {
-        NSLog(@"Failed to remove annotation.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to remove annotation."] callbackId:command.callbackId];
     }
 }
 
@@ -1510,9 +1517,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     } else if ([jsonValue isKindOfClass:NSDictionary.class])  {
         data = [NSJSONSerialization dataWithJSONObject:jsonValue options:0 error:nil];
     } else {
-        NSLog(@"Invalid JSON Annotations.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid Instant JSON payload."] callbackId:command.callbackId];
         return;
     }
 
@@ -1526,9 +1531,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
                                     callbackId:command.callbackId];
     } else {
-        NSLog(@"Failed to add annotations.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to add annotations."] callbackId:command.callbackId];
     }
 }
 
@@ -1560,9 +1563,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSString *fullyQualifiedName = [command argumentAtIndex:0];
 
     if (fullyQualifiedName.length == 0) {
-        NSLog(@"Invalid fully qualified name.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid fully qualified name."] callbackId:command.callbackId];
         return;
     }
 
@@ -1592,9 +1593,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSString *fullyQualifiedName = [command argumentAtIndex:1];
 
     if (fullyQualifiedName.length == 0) {
-        NSLog(@"Invalid fully qualified name.");
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
-                                    callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid fully qualified name."] callbackId:command.callbackId];
         return;
     }
 
@@ -1622,4 +1621,77 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         }
     }
 }
+
+#pragma mark - XFDF
+
+- (void)importXFDF:(CDVInvokedUrlCommand *)command {
+    NSString *xfdfFilePath = [command argumentAtIndex:0];
+    // Validate the XFDF file path.
+    if (xfdfFilePath.length == 0) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The XFDF path must be a valid string."] callbackId:command.callbackId];
+        return;
+    }
+
+    NSURL *xfdfFileURL = [self fileURLWithPath:xfdfFilePath];
+    if (![NSFileManager.defaultManager fileExistsAtPath:(NSString *)xfdfFileURL.path]) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The XFDF file does not exisit."] callbackId:command.callbackId];
+        return;
+    }
+
+    PSPDFDocument *document = self.pdfController.document;
+    VALIDATE_DOCUMENT(document)
+
+    PSPDFFileDataProvider *dataProvider = [[PSPDFFileDataProvider alloc] initWithFileURL:xfdfFileURL];
+    PSPDFXFDFParser *parser = [[PSPDFXFDFParser alloc] initWithDataProvider:dataProvider documentProvider:document.documentProviders[0]];
+
+    NSError *error;
+    if (![parser parseWithError:&error]) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+
+    // Import annotations to the document.
+    NSArray <PSPDFAnnotation *> *annotations = parser.annotations;
+    if (annotations) {
+        [document addAnnotations:annotations options:nil];
+    }
+}
+
+- (void)exportXFDF:(CDVInvokedUrlCommand *)command {
+    NSString *xfdfFilePath = [command argumentAtIndex:0];
+    // Validate the XFDF file path.
+    if (xfdfFilePath.length == 0) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR]
+                                    callbackId:command.callbackId];
+        return;
+    }
+
+    // Always overwrite the XFDF file we export to.
+    NSURL *xfdfFileURL = [self writableFileURLWithPath:xfdfFilePath override:YES copyIfNeeded:NO];
+    PSPDFDocument *document = self.pdfController.document;
+    VALIDATE_DOCUMENT(document)
+
+    // Collect all existing annotations from the document
+    NSMutableArray *annotations = [NSMutableArray array];
+    for (NSArray *pageAnnotations in [document allAnnotationsOfType:PSPDFAnnotationTypeAll].allValues) {
+        [annotations addObjectsFromArray:pageAnnotations];
+    }
+    // Write to the XFDF file.
+    NSError *error;
+    PSPDFFileDataSink *dataSink = [[PSPDFFileDataSink alloc] initWithFileURL:xfdfFileURL options:PSPDFDataSinkOptionNone error:&error];
+    if (dataSink) {
+        if (![[PSPDFXFDFWriter new] writeAnnotations:annotations toDataSink:dataSink documentProvider:document.documentProviders[0] error:&error]) {
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                          messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    } else {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
 @end

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -398,8 +398,13 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 }
 
 - (NSURL *)writableFileURLWithPath:(NSString *)path override:(BOOL)override copyIfNeeded:(BOOL)copyIfNeeded {
-    NSString *docsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
-    NSURL *writableFileURL = [NSURL fileURLWithPath:[docsFolder stringByAppendingPathComponent:path]];
+    NSURL *writableFileURL;
+    if (path.absolutePath) {
+        writableFileURL = [NSURL fileURLWithPath:path];
+    } else {
+        NSString *docsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+        writableFileURL = [NSURL fileURLWithPath:[docsFolder stringByAppendingPathComponent:path]];
+    }
 
     NSFileManager *fileManager = NSFileManager.defaultManager;
     if (override) {

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1433,7 +1433,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     if (annotationsJSON) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{@"annotations" : annotationsJSON}];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:@{@"localizedDescription": @"Failed to get annotations"}];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to get annotations."];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -1508,7 +1508,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     if (annotationsJSON) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:annotationsJSON];
     }  else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:@{@"localizedDescription": @"Failed to get annotations"}];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to get unsaved annotations"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -1587,7 +1587,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     if (formFieldValue) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{@"value": formFieldValue}];
     }  else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:@{@"localizedDescription": @"Failed to get annotations"}];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to get form field value."];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1684,7 +1684,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     if (dataSink) {
         if (![[PSPDFXFDFWriter new] writeAnnotations:annotations toDataSink:dataSink documentProvider:document.documentProviders[0] error:&error]) {
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                          messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+                                                          messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domain": error.domain}];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
     } else {

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1634,7 +1634,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 
     NSURL *xfdfFileURL = [self fileURLWithPath:xfdfFilePath];
     if (![NSFileManager.defaultManager fileExistsAtPath:(NSString *)xfdfFileURL.path]) {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The XFDF file does not exisit."] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The XFDF file does not exist."] callbackId:command.callbackId];
         return;
     }
 

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1689,7 +1689,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         }
     } else {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domain": error.domain}];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
 }

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1647,7 +1647,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSError *error;
     if (![parser parseWithError:&error]) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domin": error.domain}];
+                                                      messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domain": error.domain}];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -408,7 +408,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
     // If we don't have a writable file already, we move the provided file to the ~/Documents folder.
     if (![fileManager fileExistsAtPath:(NSString *)writableFileURL.path]) {
-        // Create the folder where the wirtable file will be saved.
+        // Create the folder where the writable file will be saved.
         NSError *createFolderError;
         if (![fileManager createDirectoryAtPath:writableFileURL.path.stringByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:&createFolderError]) {
             NSLog(@"Failed to create directory: %@", createFolderError.localizedDescription);

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -203,5 +203,10 @@ var PSPDFKitPlugin = new function() {
         getFormFieldValue: ['fullyQualifiedName', 'callback'],
     });
     
+    // XFDF
+    addMethods({
+        importXFDF: ['xfdfPath', 'callback'],
+        exportXFDF: ['xfdfPath', 'callback'],
+    });
 };
 module.exports = PSPDFKitPlugin;

--- a/README.md
+++ b/README.md
@@ -433,6 +433,17 @@ The following methods allow you to programmatically fill forms and get the value
     // Gets the form field value by specifying its fully qualified name.
     getFormFieldValue(fullyQualifiedName, callback(value));
     
+XFDF API
+---------------
+
+The following methods allow you to import and export from/to a given XFDF file.
+
+    // Imports all annotations from the specified XFDF file to the current document.
+    importXFDF(xfdfPath, callback(value));
+	
+    // Exports all annotations from the current document to the specified XFDF file path in "~/Documents/xfdfPath".
+    exportXFDF(xfdfPath, callback(value));
+    
 License
 ------------
 

--- a/README.md
+++ b/README.md
@@ -407,19 +407,19 @@ The methods below allows you to programmatically access, add, and remove annotat
 
     // Apply Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
     // Can be used to add annotations, bookmarks, fill forms, etc.
-    applyInstantJSON(jsonValue, [callback]);
+    applyInstantJSON(jsonValue, callback(error));
 
     // Add a single annotation using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
-    addAnnotation(jsonAnnotation, [callback]);
+    addAnnotation(jsonAnnotation, callback(error));
 
     // Remove an annotation.
-    removeAnnotation(jsonAnnotation, [callback]);
+    removeAnnotation(jsonAnnotation, callback(error);
     
     // Get all the annotations at the specified page index by type.
-    getAnnotations(pageIndex, type, [callback]);
+    getAnnotations(pageIndex, type, callback(valueOrError));
     
     // Get all unsaved annotations.
-    getAllUnsavedAnnotations(callback(value));
+    getAllUnsavedAnnotations(callback(valueOrError));
 
     
 Forms API
@@ -428,10 +428,10 @@ Forms API
 The following methods allow you to programmatically fill forms and get the value of a form field.
 
     // Sets the form field value by specifying its fully qualified name.
-    setFormFieldValue(value, fullyQualifiedName, [callback]);
+    setFormFieldValue(value, fullyQualifiedName, callback(error));
     
     // Gets the form field value by specifying its fully qualified name.
-    getFormFieldValue(fullyQualifiedName, callback(value));
+    getFormFieldValue(fullyQualifiedName, callback(valueOrError));
     
 XFDF API
 ---------------
@@ -439,10 +439,10 @@ XFDF API
 The following methods allow you to import and export from/to a given XFDF file.
 
     // Imports all annotations from the specified XFDF file to the current document.
-    importXFDF(xfdfPath, callback(value));
+    importXFDF(xfdfPath, callback(error)));
 	
     // Exports all annotations from the current document to the specified XFDF file path in '"~/Documents/" + xfdfPath'.
-    exportXFDF(xfdfPath, callback(value));
+    exportXFDF(xfdfPath, callback(error));
     
 License
 ------------

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ The following methods allow you to import and export from/to a given XFDF file.
     // Imports all annotations from the specified XFDF file to the current document.
     importXFDF(xfdfPath, callback(value));
 	
-    // Exports all annotations from the current document to the specified XFDF file path in "~/Documents/xfdfPath".
+    // Exports all annotations from the current document to the specified XFDF file path in '"~/Documents/" + xfdfPath'.
     exportXFDF(xfdfPath, callback(value));
     
 License

--- a/README.md
+++ b/README.md
@@ -407,19 +407,19 @@ The methods below allows you to programmatically access, add, and remove annotat
 
     // Apply Instant JSON Document payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-document-json-api 
     // Can be used to add annotations, bookmarks, fill forms, etc.
-    applyInstantJSON(jsonValue, callback(error));
+    applyInstantJSON(jsonValue, [callback]);
 
     // Add a single annotation using an Instant JSON Annotation payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
-    addAnnotation(jsonAnnotation, callback(error));
+    addAnnotation(jsonAnnotation, [callback]);
 
     // Remove an annotation.
-    removeAnnotation(jsonAnnotation, callback(error);
+    removeAnnotation(jsonAnnotation, [callback]);
     
     // Get all the annotations at the specified page index by type.
-    getAnnotations(pageIndex, type, callback(valueOrError));
+    getAnnotations(pageIndex, type, [callback]);
     
     // Get all unsaved annotations.
-    getAllUnsavedAnnotations(callback(valueOrError));
+    getAllUnsavedAnnotations([callback]);
 
     
 Forms API
@@ -428,10 +428,10 @@ Forms API
 The following methods allow you to programmatically fill forms and get the value of a form field.
 
     // Sets the form field value by specifying its fully qualified name.
-    setFormFieldValue(value, fullyQualifiedName, callback(error));
+    setFormFieldValue(value, fullyQualifiedName, [callback]);
     
     // Gets the form field value by specifying its fully qualified name.
-    getFormFieldValue(fullyQualifiedName, callback(valueOrError));
+    getFormFieldValue(fullyQualifiedName, [callback]);
     
 XFDF API
 ---------------
@@ -439,10 +439,10 @@ XFDF API
 The following methods allow you to import and export from/to a given XFDF file.
 
     // Imports all annotations from the specified XFDF file to the current document.
-    importXFDF(xfdfPath, callback(error)));
+    importXFDF(xfdfPath, [callback]);
 	
     // Exports all annotations from the current document to the specified XFDF file path in '"~/Documents/" + xfdfPath'.
-    exportXFDF(xfdfPath, callback(error));
+    exportXFDF(xfdfPath, [callback]);
     
 License
 ------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.2.8" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.2.9" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>


### PR DESCRIPTION
Adds the following methods:

```
// Imports all annotations from the specified XFDF file to the current document.
importXFDF(xfdfPath, callback(value));
	
// Exports all annotations from the current document to the specified XFDF file path in "~/Documents/xfdfPath".
exportXFDF(xfdfPath, callback(value));
```