### PR TITLE
Allow passing Instant JSON annotation types

### DIFF
--- a/CordovaDemo/platforms/ios/CordovaDemo.xcodeproj/project.pbxproj
+++ b/CordovaDemo/platforms/ios/CordovaDemo.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
@@ -348,7 +349,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "NODEJS_PATH=/usr/local/bin; NVM_NODE_PATH=~/.nvm/versions/node/`nvm version 2>/dev/null`/bin; N_NODE_PATH=`find /usr/local/n/versions/node/* -maxdepth 0 -type d 2>/dev/null | tail -1`/bin; XCODE_NODE_PATH=`xcode-select --print-path`/usr/share/xcs/Node/bin; PATH=$NODEJS_PATH:$NVM_NODE_PATH:$N_NODE_PATH:$XCODE_NODE_PATH:$PATH && node cordova/lib/copy-www-build-step.js";
+			shellScript = "NODEJS_PATH=/usr/local/bin; NVM_NODE_PATH=~/.nvm/versions/node/`nvm version 2>/dev/null`/bin; N_NODE_PATH=`find /usr/local/n/versions/node/* -maxdepth 0 -type d 2>/dev/null | tail -1`/bin; XCODE_NODE_PATH=`xcode-select --print-path`/usr/share/xcs/Node/bin; PATH=$NODEJS_PATH:$NVM_NODE_PATH:$N_NODE_PATH:$XCODE_NODE_PATH:$PATH && node cordova/lib/copy-www-build-step.js\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1561,7 +1561,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     return [annotationsJSON copy];
 }
 
-- (PSPDFAnnotationType)annotationTypeFromInstantJSON:(NSString *)typeString {
+- (PSPDFAnnotationType)annotationTypeFromString:(NSString *)typeString {
     if (typeString.length == 0) {
         return PSPDFAnnotationTypeAll;
     }

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1421,7 +1421,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 
 - (void)getAnnotations:(CDVInvokedUrlCommand *)command {
     PSPDFPageIndex pageIndex = (PSPDFPageIndex)[[command argumentAtIndex:0] longLongValue];
-    PSPDFAnnotationType type = [self annotationTypeFromInstantJSON:(NSString *)[command argumentAtIndex:1]];
+    PSPDFAnnotationType type = [self annotationTypeFromString:(NSString *)[command argumentAtIndex:1]];
     PSPDFDocument *document = self.pdfController.document;
     VALIDATE_DOCUMENT(document);
 
@@ -1562,11 +1562,35 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 }
 
 - (PSPDFAnnotationType)annotationTypeFromString:(NSString *)typeString {
-    if (typeString.length == 0) {
+    if (!typeString) {
         return PSPDFAnnotationTypeAll;
+    } else if ([typeString isEqualToString:@"pspdfkit/ink"]) {
+        return PSPDFAnnotationTypeInk;
+    } else if ([typeString isEqualToString:@"pspdfkit/link"]) {
+        return PSPDFAnnotationTypeLink;
+    } else if ([typeString isEqualToString:@"pspdfkit/markup/highlight"]) {
+        return PSPDFAnnotationTypeHighlight;
+    } else if ([typeString isEqualToString:@"pspdfkit/markup/squiggly"]) {
+        return PSPDFAnnotationTypeSquiggly;
+    } else if ([typeString isEqualToString:@"pspdfkit/markup/strikeout"]) {
+        return PSPDFAnnotationTypeStrikeOut;
+    } else if ([typeString isEqualToString:@"pspdfkit/markup/underline"]) {
+        return PSPDFAnnotationTypeUnderline;
+    } else if ([typeString isEqualToString:@"pspdfkit/note"]) {
+        return PSPDFAnnotationTypeNote;
+    } else if ([typeString isEqualToString:@"pspdfkit/shape/ellipse"]) {
+        return PSPDFAnnotationTypeCircle;
+    } else if ([typeString isEqualToString:@"pspdfkit/shape/line"]) {
+        return PSPDFAnnotationTypeLine;
+    } else if ([typeString isEqualToString:@"pspdfkit/shape/polygon"]) {
+        return PSPDFAnnotationTypePolygon;
+    } else if ([typeString isEqualToString:@"pspdfkit/shape/rectangle"]) {
+        return PSPDFAnnotationTypeSquare;
+    } else if ([typeString isEqualToString:@"pspdfkit/text"]) {
+        return PSPDFAnnotationTypeFreeText;
+    } else {
+        return (PSPDFAnnotationType)[self optionsValueForKeys:@[[typeString stringByReplacingOccurrencesOfString:@"pspdfkit/" withString:@""]] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
     }
-    // Strip the `pspdfkit/` prefix from the annotation type if present.
-    return (PSPDFAnnotationType)[self optionsValueForKeys:@[[typeString stringByReplacingOccurrencesOfString:@"pspdfkit/" withString:@""]] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
 }
 
 #pragma mark - Forms

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1421,8 +1421,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 
 - (void)getAnnotations:(CDVInvokedUrlCommand *)command {
     PSPDFPageIndex pageIndex = (PSPDFPageIndex)[[command argumentAtIndex:0] longLongValue];
-    PSPDFAnnotationType type = (PSPDFAnnotationType) [self optionsValueForKeys:@[[command argumentAtIndex:1]] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
-
+    PSPDFAnnotationType type = [self annotationTypeFromInstantJSON:(NSString *)[command argumentAtIndex:1]];
     PSPDFDocument *document = self.pdfController.document;
     VALIDATE_DOCUMENT(document);
 
@@ -1560,6 +1559,14 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     }
 
     return [annotationsJSON copy];
+}
+
+- (PSPDFAnnotationType)annotationTypeFromInstantJSON:(NSString *)typeString {
+    if (typeString.length == 0) {
+        return PSPDFAnnotationTypeAll;
+    }
+    // Strip the `pspdfkit/` prefix from the annotation type if present.
+    return (PSPDFAnnotationType)[self optionsValueForKeys:@[[typeString stringByReplacingOccurrencesOfString:@"pspdfkit/" withString:@""]] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
 }
 
 #pragma mark - Forms


### PR DESCRIPTION
This PR allows passing Instant JSON annotation types to `getAnnotations`. For example, passing ` 'pspdfkit/ink'`, like so:

```js
PSPDFKit.getAnnotations(0, 'pspdfkit/ink', function(success, error) {
	if (success !== null) {
		// Get all annotations on the first page.
		const annotations = success
	} else {
		// Handle Error.
	}
});
```