### PR TITLE
Adds Document Processing API

### DIFF
--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -209,6 +209,11 @@ var PSPDFKitPlugin = new function() {
         importXFDF: ['xfdfPath', 'callback'],
         exportXFDF: ['xfdfPath', 'callback'],
     });
+	
+    // Document Processing
+    addMethods({
+        processAnnotations: ['annotationChange', 'processedDocumentPath', 'callback', 'annotationType'],
+    });
 };
 module.exports = PSPDFKitPlugin;
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 PSPDFKit GmbH
+Copyright (c) 2015-2019 PSPDFKit GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1759,7 +1759,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSURL *processedDocumentURL = [self writableFileURLWithPath:[command argumentAtIndex:1] override:YES copyIfNeeded:NO];
 
     // The annotation type is optional. We default to `All` if it's not specified.
-    NSString *typeString = [command argumentAtIndex:2] ?: [command argumentAtIndex:3];
+    NSString *typeString = [command argumentAtIndex:2];
     PSPDFAnnotationType type = PSPDFAnnotationTypeAll;
     if (typeString.length > 0) {
         type = (PSPDFAnnotationType) [self optionsValueForKeys:@[typeString] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];

--- a/PSPDFKitPlugin/PSPDFKitPlugin.m
+++ b/PSPDFKitPlugin/PSPDFKitPlugin.m
@@ -1759,7 +1759,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSURL *processedDocumentURL = [self writableFileURLWithPath:[command argumentAtIndex:1] override:YES copyIfNeeded:NO];
 
     // The annotation type is optional. We default to `All` if it's not specified.
-    NSString *typeString = [command argumentAtIndex:2];
+    NSString *typeString = [command argumentAtIndex:2] ?: [command argumentAtIndex:3];
     PSPDFAnnotationType type = PSPDFAnnotationTypeAll;
     if (typeString.length > 0) {
         type = (PSPDFAnnotationType) [self optionsValueForKeys:@[typeString] ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -208,5 +208,10 @@ var PSPDFKitPlugin = new function() {
         importXFDF: ['xfdfPath', 'callback'],
         exportXFDF: ['xfdfPath', 'callback'],
     });
+	
+    // Document Processing
+    addMethods({
+        processAnnotations: ['annotationChange', 'processedDocumentPath', 'callback', 'annotationType'],
+    });
 };
 module.exports = PSPDFKitPlugin;

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The plugin functions currently implemented are:
     
 Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
 
-The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
+The `options` parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
 
 The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
 
@@ -141,9 +141,9 @@ The optional callback will be called once the PDF controller has fully appeared 
 
 Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
 
-The xfdfPath should be a string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in `'"~/Documents/" + xfdfPath'`). To specify a path inside the application documents or library directory, use a ~, e.g. `"~/Documents/myXFDF.xfdf"` or `"~/Library/Application Support/myXFDF.xfdf"`. The xfdfPath cannot be null and must not be omitted.
+The `xfdfPath` should be a string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in `'"~/Documents/" + xfdfPath'`). To specify a path inside the application documents or library directory, use a ~, e.g. `"~/Documents/myXFDF.xfdf"` or `"~/Library/Application Support/myXFDF.xfdf"`. The xfdfPath cannot be null and must not be omitted.
 
-The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
+The `options` parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
 
 The optional callback will be called once the PDF controller has fully appeared on screen. Calling present() when there is already a PDF presented will load the new PDF in the current modal (in which case the callback will fire immediately).
 
@@ -456,12 +456,12 @@ The following method allows you to process annotations (embed, remove, flatten, 
 
 The `annotationChange` is a string parameter. Can be `flatten`, `remove`, `embed` or `print`.
 
-The processedDocumentPath should be a string containing the file path (not URL) for the processed PDF document. Relative paths are assumed to be relative to the www directory (if the 
-processed document path has a different base URL set, we will create a processed file in '"~/Documents/" + processedDocumentPath'). To specify a path inside the application documents or library directory, use a `~,` e.g. `"~/Documents/processedDocument.pdf"` or `"~/Library/Application Support/processedDocument.pdf"`. The processedDocumentPath cannot be null and must not be omitted.
+The `processedDocumentPath` should be a string containing the file path (not URL) for the processed PDF document. Relative paths are assumed to be relative to the www directory (if the 
+processed document path has a different base URL set, we will create a processed file in '"~/Documents/" + processedDocumentPath'). To specify a path inside the application documents or library directory, use a `~,` e.g. `"~/Documents/processedDocument.pdf"` or `"~/Library/Application Support/processedDocument.pdf"`. The `processedDocumentPath` cannot be null and must not be omitted.
 
 The optional callback will be called when the PDF is processed.
 
-The optional string annotationType argument. If omitted, we process 'All' annotations. The annotation type can have one of the following values: None, Undefined, Link, Highlight, StrikeOut, Underline, Squiggly, FreeText, Ink, Square, Circle, Line, Text, Stamp, Caret, RichMedia, Screen, Widget, Sound, FileAttachment, Polygon, PolyLine, Popup, Watermark, TrapNet, 3D, Redact, All. 
+The optional string `annotationType` argument. If omitted, we process `'All'` annotations. The annotation type can have one of the following values: None, Undefined, Link, Highlight, StrikeOut, Underline, Squiggly, FreeText, Ink, Square, Circle, Line, Text, Stamp, Caret, RichMedia, Screen, Widget, Sound, FileAttachment, Polygon, PolyLine, Popup, Watermark, TrapNet, 3D, Redact, All. 
 
 License
 ------------

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The optional string annotationType argument. If omitted, we process 'All' annota
 License
 ------------
 
-Copyright 2011-2018 PSPDFKit GmbH. All rights reserved.
+Copyright 2011-2019 PSPDFKit GmbH. All rights reserved.
 
 THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY AUSTRIAN COPYRIGHT LAW
 AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ The following methods allow you to import and export from/to a given XFDF file.
 Document Processing API
 -----------------------
 
-The following method allows you to process annotation (embed, remove, flatten, or print) and save them to the given document path.
+The following method allows you to process annotations (embed, remove, flatten, or print) and save the processed document to the given document path.
 
     // Processes the current document's annotations and saves the processed document at the specified path.
     processAnnotations(annotationChange, processedDocumentPath, [callback], [annotationType])

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ The following method allows you to process annotations (embed, remove, flatten, 
     processAnnotations(annotationChange, processedDocumentPath, [callback], [annotationType])
 	
 
-The annotationChange is a string parameter. Can be flatten, remove, embed or print.
+The `annotationChange` is a string parameter. Can be `flatten`, `remove`, `embed` or `print`.
 
 The processedDocumentPath should be a string containing the file path (not URL) for the processed PDF document. Relative paths are assumed to be relative to the www directory (if the 
 processed document path has a different base URL set, we will create a processed file in '"~/Documents/" + processedDocumentPath'). To specify a path inside the application documents or library directory, use a `~,` e.g. `"~/Documents/processedDocument.pdf"` or `"~/Library/Application Support/processedDocument.pdf"`. The processedDocumentPath cannot be null and must not be omitted.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The plugin functions currently implemented are:
 
     present(path, [callback], [options]);
     
-Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
+Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
 
 The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
 
@@ -139,9 +139,9 @@ The optional callback will be called once the PDF controller has fully appeared 
 
     presentWithXFDF(path, xfdfPath, [callback], [options]);
 
-Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/mypdf.pdf" or "~/Library/Application Support/mypdf.pdf". Path can be null, but must not be omitted
+Displays a PDF in a full-screen modal. The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
 
-The xfdfPath should be a  string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in '"~/Documents/" + xfdfPath'). To specify a path inside the application documents or library directory, use a ~, e.g. "~/Documents/myXFDF.xfdf" or "~/Library/Application Support/myXFDF.xfdf". The xfdfPath cannot be null and must not be omitted.
+The xfdfPath should be a string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in `'"~/Documents/" + xfdfPath'`). To specify a path inside the application documents or library directory, use a ~, e.g. `"~/Documents/myXFDF.xfdf"` or `"~/Library/Application Support/myXFDF.xfdf"`. The xfdfPath cannot be null and must not be omitted.
 
 The options parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
 
@@ -444,6 +444,25 @@ The following methods allow you to import and export from/to a given XFDF file.
     // Exports all annotations from the current document to the specified XFDF file path in '"~/Documents/" + xfdfPath'.
     exportXFDF(xfdfPath, [callback]);
     
+
+Document Processing API
+-----------------------
+
+The following method allows you to process annotation (embed, remove, flatten, or print) and save them to the given document path.
+
+    // Processes the current document's annotations and saves the processed document at the specified path.
+    processAnnotations(annotationChange, processedDocumentPath, [callback], [annotationType])
+	
+
+The annotationChange is a string parameter. Can be flatten, remove, embed or print.
+
+The processedDocumentPath should be a string containing the file path (not URL) for the processed PDF document. Relative paths are assumed to be relative to the www directory (if the 
+processed document path has a different base URL set, we will create a processed file in '"~/Documents/" + processedDocumentPath'). To specify a path inside the application documents or library directory, use a `~,` e.g. `"~/Documents/processedDocument.pdf"` or `"~/Library/Application Support/processedDocument.pdf"`. The processedDocumentPath cannot be null and must not be omitted.
+
+The optional callback will be called when the PDF is processed.
+
+The optional string annotationType argument. If omitted, we process 'All' annotations. The annotation type can have one of the following values: None, Undefined, Link, Highlight, StrikeOut, Underline, Squiggly, FreeText, Ink, Square, Circle, Line, Text, Stamp, Caret, RichMedia, Screen, Widget, Sound, FileAttachment, Polygon, PolyLine, Popup, Watermark, TrapNet, 3D, Redact, All. 
+
 License
 ------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.2.9" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>
 	<name>PSPDFKitPlugin</name>
-	<license>Copyright 2011-2018 PSPDFKit GmbH. All rights reserved.
+	<license>Copyright 2011-2019 PSPDFKit GmbH. All rights reserved.
 THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY AUSTRIAN COPYRIGHT LAW AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT. UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
 http://pspdfkit.com/license.html</license>
 	<platform name="ios">


### PR DESCRIPTION
Fixes #82 

---

Came up in Z#14650. This PR adds the ability to process annotations and save them to the specified processed document path.

## Usage

```js
// Flatten ink annotations from the current document.
PSPDFKitPlugin.processAnnotations('flatten', 'pdf/processed.pdf', function(success) { 
	if (success) {
		console.log("Successfully processed annotation"); 
	}
}, 'Ink');
```