### PR TITLE
Improve error handling

### DIFF
--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -33,9 +33,9 @@ var PSPDFKitPlugin = new function() {
                         }
                     }
                     cordova.exec(function (result) {
-                        if (callback) callback(result);
+                        if (callback) callback(result, null);
                     }, function (error) {
-                        alert(error);
+                        if (callback) callback(null, error); else console.log(error);
                     }, 'PSPDFKitPlugin', methodName, argArray);
                 }
             })();

--- a/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
+++ b/CordovaDemo/platforms/ios/www/plugins/pspdfkit-cordova-ios/PSPDFKitPlugin/pspdfkit.js
@@ -35,7 +35,8 @@ var PSPDFKitPlugin = new function() {
                     cordova.exec(function (result) {
                         if (callback) callback(result, null);
                     }, function (error) {
-                        if (callback) callback(null, error); else console.log(error);
+                        console.log(error);
+                        if (callback) callback(null, error);
                     }, 'PSPDFKitPlugin', methodName, argArray);
                 }
             })();

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -34,7 +34,8 @@ var PSPDFKitPlugin = new function() {
                     cordova.exec(function (result) {
                         if (callback) callback(result, null);
                     }, function (error) {
-                        if (callback) callback(null, error); else console.log(error);
+                        console.log(error);
+                        if (callback) callback(null, error);
                     }, 'PSPDFKitPlugin', methodName, argArray);
                 }
             })();

--- a/PSPDFKitPlugin/pspdfkit.js
+++ b/PSPDFKitPlugin/pspdfkit.js
@@ -32,9 +32,9 @@ var PSPDFKitPlugin = new function() {
                         }
                     }
                     cordova.exec(function (result) {
-                        if (callback) callback(result);
+                        if (callback) callback(result, null);
                     }, function (error) {
-                        alert(error);
+                        if (callback) callback(null, error); else console.log(error);
                     }, 'PSPDFKitPlugin', methodName, argArray);
                 }
             })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-ios",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "PSPDFKit Cordova Plugin for iOS",
   "cordova": {
     "id": "pspdfkit-cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="pspdfkit-cordova-ios" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="pspdfkit-cordova-ios" version="1.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<engines>
 		<engine name="cordova" version=">=6.3.1"/>
 	</engines>


### PR DESCRIPTION
This came up in Z#14617.

---

This PR improves error handling:

1. We no longer present an alert if an error occurs in `addMethods`.
2. The callback now has two parameters: result and error.

### Usage:

```js
PSPDFKitPlugin.processAnnotations('flatten', 'pdf/processed.pdf', function(result, error) { 
    if (result) {
        alert("Successfully processed annotations: " + result); 
    } else {
        alert("An error has occurred: " + error); 
    }
}, 'Ink');
```

| Success | Error |
| -------- | ----- |
| <img width="584" alt="Screen Shot 2019-07-09 at 5 40 51 PM" src="https://user-images.githubusercontent.com/7443038/60925342-61f59780-a271-11e9-8707-fd95592f81ea.png"> | <img width="584" alt="Screen Shot 2019-07-09 at 5 43 10 PM" src="https://user-images.githubusercontent.com/7443038/60925350-68840f00-a271-11e9-8dda-19b1037193cd.png"> |